### PR TITLE
New config option DisableSilkTouchOreBreaks

### DIFF
--- a/src/main/java/com/hm/achievement/AdvancedAchievements.java
+++ b/src/main/java/com/hm/achievement/AdvancedAchievements.java
@@ -771,6 +771,14 @@ public class AdvancedAchievements extends JavaPlugin {
 			updateDone = true;
 		}
 
+		if (!config.getKeys(false).contains("DisableSilkTouchOreBreaks")) {
+			config.set("DisableSilkTouchOreBreaks", false,
+					new String[] {
+							"Do not take into account ores broken with Silk Touch for the Breaks achievements.",
+							"DisableSilkTouchBreaks takes precedence over this."});
+			updateDone = true;
+		}
+
 		if (!config.getKeys(false).contains("ObfuscateProgressiveAchievements")) {
 			config.set("ObfuscateProgressiveAchievements", false,
 					new String[] { "Obfuscate progressive achievements:",

--- a/src/main/java/com/hm/achievement/listener/AchieveBlockBreakListener.java
+++ b/src/main/java/com/hm/achievement/listener/AchieveBlockBreakListener.java
@@ -40,11 +40,11 @@ public class AchieveBlockBreakListener implements Listener {
 
 		Player player = event.getPlayer();
 		if (plugin.isRestrictCreative() && player.getGameMode() == GameMode.CREATIVE || plugin.isInExludedWorld(player)
-				|| disableSilkTouchBreaks && (version >= 9
+				|| disableSilkTouchBreaks && version >= 9
 						&& event.getPlayer().getInventory().getItemInMainHand()
 								.containsEnchantment(Enchantment.SILK_TOUCH)
-						|| version < 9
-								&& event.getPlayer().getItemInHand().containsEnchantment(Enchantment.SILK_TOUCH)))
+						|| disableSilkTouchBreaks && version < 9
+								&& event.getPlayer().getItemInHand().containsEnchantment(Enchantment.SILK_TOUCH))
 			return;
 		Block block = event.getBlock();
 		String blockName = block.getType().name().toLowerCase();

--- a/src/main/java/com/hm/achievement/listener/AchieveBlockBreakListener.java
+++ b/src/main/java/com/hm/achievement/listener/AchieveBlockBreakListener.java
@@ -60,7 +60,6 @@ public class AchieveBlockBreakListener implements Listener {
 				case DIAMOND_ORE:
 				case EMERALD_ORE:
 				case GOLD_ORE:
-				case IRON_ORE:
 				case LAPIS_ORE:
 				case QUARTZ_ORE:
 				case REDSTONE_ORE:

--- a/src/main/java/com/hm/achievement/listener/AchieveBlockBreakListener.java
+++ b/src/main/java/com/hm/achievement/listener/AchieveBlockBreakListener.java
@@ -23,12 +23,14 @@ public class AchieveBlockBreakListener implements Listener {
 	private AdvancedAchievements plugin;
 	private int version;
 	private boolean disableSilkTouchBreaks;
+	private boolean disableSilkTouchOreBreaks;
 
 	public AchieveBlockBreakListener(AdvancedAchievements plugin) {
 
 		this.plugin = plugin;
 		// Load configuration parameter.
 		disableSilkTouchBreaks = plugin.getPluginConfig().getBoolean("DisableSilkTouchBreaks", false);
+		disableSilkTouchOreBreaks = plugin.getPluginConfig().getBoolean("DisableSilkTouchOreBreaks", false);
 		// Simple and fast check to compare versions. Might need to be updated in the future depending on how the
 		// Minecraft versions change in the future.
 		version = Integer.parseInt(PackageType.getServerVersion().split("_")[1]);
@@ -39,14 +41,35 @@ public class AchieveBlockBreakListener implements Listener {
 	public void onBlockBreak(BlockBreakEvent event) {
 
 		Player player = event.getPlayer();
-		if (plugin.isRestrictCreative() && player.getGameMode() == GameMode.CREATIVE || plugin.isInExludedWorld(player)
-				|| disableSilkTouchBreaks && version >= 9
-						&& event.getPlayer().getInventory().getItemInMainHand()
-								.containsEnchantment(Enchantment.SILK_TOUCH)
-						|| disableSilkTouchBreaks && version < 9
-								&& event.getPlayer().getItemInHand().containsEnchantment(Enchantment.SILK_TOUCH))
+		boolean silkTouchBreak = (
+				version >= 9 && event.getPlayer().getInventory().getItemInMainHand()
+						.containsEnchantment(Enchantment.SILK_TOUCH)) ||
+				version < 9 && event.getPlayer().getItemInHand()
+						.containsEnchantment(Enchantment.SILK_TOUCH);
+
+		if (plugin.isRestrictCreative() && player.getGameMode() == GameMode.CREATIVE ||
+				plugin.isInExludedWorld(player) ||
+				disableSilkTouchBreaks && silkTouchBreak) {
 			return;
+		}
+
 		Block block = event.getBlock();
+		if (disableSilkTouchOreBreaks && silkTouchBreak) {
+			switch (block.getType()) {
+				case COAL_ORE:
+				case DIAMOND_ORE:
+				case EMERALD_ORE:
+				case GOLD_ORE:
+				case IRON_ORE:
+				case LAPIS_ORE:
+				case QUARTZ_ORE:
+				case REDSTONE_ORE:
+					return;
+				default:
+					break;
+			}
+		}
+
 		String blockName = block.getType().name().toLowerCase();
 		if (player.hasPermission("achievement.count.breaks." + blockName + "." + block.getData())
 				&& plugin.getPluginConfig().isConfigurationSection("Breaks." + blockName + ":" + block.getData()))

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -106,6 +106,10 @@ BookChronologicalOrder: true
 # Do not take into account items broken with Silk Touch for the Breaks achievements.
 DisableSilkTouchBreaks: false
 
+# Do not take into account ores broken with Silk Touch for the Breaks achievements.
+# DisableSilkTouchBreaks takes precedence over this.
+DisableSilkTouchOreBreaks: false
+
 #=============================OOO=============================#
 # III-----------------------------------------------------III #
 # |                    Database settings                    | #


### PR DESCRIPTION
We noticed that breaks of ores were not being logged even though we had `DisableSilkTouchBreaks` false.  My first commit fixed that bug (misplaced parenthesis: https://github.com/AddstarMC/AdvancedAchievements/commit/337c41a6cc00d4e841ec49d91e02d35237e5aab0#diff-d7fcdcb9d7c577c3340e1ea0ad1fe955R43).  I then decided to add option `DisableSilkTouchOreBreaks`.  

With `DisableSilkTouchBreaks` false and `DisableSilkTouchOreBreaks` true, breaks of stone with a silk touch pick count, but breaks of ores with a silk touch pick do not count.  The idea is to prevent somebody from placing 128 diamond ores, breaking them with a silk touch pick, then placing them again, breaking again, etc.