### PR TITLE
Null safety handling

### DIFF
--- a/src/main/java/com/hm/achievement/api/AdvancedAchievementsAPI.java
+++ b/src/main/java/com/hm/achievement/api/AdvancedAchievementsAPI.java
@@ -29,8 +29,8 @@ public interface AdvancedAchievementsAPI {
 	 * Achievements caching when player is online and if method called from server thread.
 	 * 
 	 * @since 5.0
-	 * @param player
-	 * @param achievementName as defined by the Name parameter in Advanced Achievements config.yml
+	 * @param player should not be null
+	 * @param achievementName as defined by the Name parameter in Advanced Achievements config.yml, should not be empty
 	 * @return true if player has received the achievement, false otherwise
 	 */
 	public boolean hasPlayerReceivedAchievement(UUID player, String achievementName);
@@ -39,7 +39,7 @@ public interface AdvancedAchievementsAPI {
 	 * Retrieves all achievements received by the player.
 	 * 
 	 * @since 5.0
-	 * @param player
+	 * @param player should not be null
 	 * @return list of {@code Achievement} objects received by the player
 	 */
 	public List<Achievement> getPlayerAchievementsList(UUID player);
@@ -49,7 +49,7 @@ public interface AdvancedAchievementsAPI {
 	 * Achievements caching when player is online.
 	 * 
 	 * @since 5.0
-	 * @param player
+	 * @param player should not be null
 	 * @return total achievements by the player
 	 */
 	public int getPlayerTotalAchievements(UUID player);
@@ -58,7 +58,7 @@ public interface AdvancedAchievementsAPI {
 	 * Retrieves the {@code Rank} object of a player over a given period.
 	 * 
 	 * @since 5.0
-	 * @param player
+	 * @param player should not be null
 	 * @param rankingPeriodStart time in millis since epoch; rank will be calculated for achievements received between
 	 *            that starting point and now
 	 * @return rank of the player; if no achievements were received over the period, his rank will be Integer.MAX_VALUE
@@ -81,8 +81,8 @@ public interface AdvancedAchievementsAPI {
 	 * player is online and if method called from server thread.
 	 * 
 	 * @since 5.0
-	 * @param player
-	 * @param category
+	 * @param player should not be null
+	 * @param category should not be null
 	 * @return the statistic for the normal category
 	 */
 	public long getStatisticForNormalCategory(UUID player, NormalAchievements category);
@@ -92,8 +92,8 @@ public interface AdvancedAchievementsAPI {
 	 * player is online and if method called from server thread.
 	 * 
 	 * @since 5.0
-	 * @param player
-	 * @param category
+	 * @param player should not be null
+	 * @param category should not be null
 	 * @param subcategory within the main multiple category
 	 * @return the statistic for the multiple category
 	 */
@@ -105,7 +105,7 @@ public interface AdvancedAchievementsAPI {
 	 * not found in Advanced Achievements's configuration, null is returned.
 	 * 
 	 * @since 5.0
-	 * @param achievementName as defined by the Name parameter in Advanced Achievements config.yml
+	 * @param achievementName as defined by the Name parameter in Advanced Achievements config.yml, should not be empty
 	 * @return the DisplayName parameter of an achievement or "" or null
 	 */
 	public String getDisplayNameForName(String achievementName);

--- a/src/test/java/com/hm/achievement/api/AdvancedAchievementsBukkitAPINullSafetyTest.java
+++ b/src/test/java/com/hm/achievement/api/AdvancedAchievementsBukkitAPINullSafetyTest.java
@@ -1,0 +1,108 @@
+package com.hm.achievement.api;
+
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.hm.achievement.AdvancedAchievements;
+import com.hm.achievement.category.MultipleAchievements;
+import com.hm.achievement.category.NormalAchievements;
+
+import utilities.MockUtility;
+
+/**
+ * Class for testing the Bukkit API (null safety).
+ *
+ * @author Pyves
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AdvancedAchievementsBukkitAPINullSafetyTest {
+
+	private AdvancedAchievementsBukkitAPI underTest;
+
+	@Rule
+	public final ExpectedException expectedException = ExpectedException.none();
+
+	@Before
+	public void setUp() {
+		AdvancedAchievements pluginMock = MockUtility.setUp().getPluginMock();
+
+		underTest = new AdvancedAchievementsBukkitAPI(pluginMock);
+	}
+
+	@Test
+	public void itShouldThrowExceptionWhenCheckingForAchievementWithNullPlayer() {
+		expectIllegalArgumentExceptionWithMessage("Player cannot be null.");
+		underTest.hasPlayerReceivedAchievement(null, "achievement-name");
+	}
+
+	@Test
+	public void itShouldThrowExceptionWhenCheckingForAchievementWithEmptyName() {
+		expectIllegalArgumentExceptionWithMessage("Achievement Name cannot be empty.");
+		underTest.hasPlayerReceivedAchievement(UUID.randomUUID(), "");
+	}
+
+	@Test
+	public void testAchievementListForNullPlayer() {
+		expectIllegalArgumentExceptionWithMessage("Player cannot be null.");
+		underTest.getPlayerAchievementsList(null);
+	}
+
+	@Test
+	public void testTotalAchievementsForNullPlayer() {
+		expectIllegalArgumentExceptionWithMessage("Player cannot be null.");
+		underTest.getPlayerTotalAchievements(null);
+	}
+
+	@Test
+	public void testRankForNullPlayer() {
+		expectIllegalArgumentExceptionWithMessage("Player cannot be null.");
+		underTest.getPlayerRank(null, 0);
+	}
+
+	@Test
+	public void testNormalStatisticForNullPlayer() {
+		expectIllegalArgumentExceptionWithMessage("Player cannot be null.");
+		underTest.getStatisticForNormalCategory(null, NormalAchievements.ARROWS);
+	}
+
+	@Test
+	public void testNormalStatisticForNullCategory() {
+		expectIllegalArgumentExceptionWithMessage("Category cannot be null.");
+		underTest.getStatisticForNormalCategory(UUID.randomUUID(), null);
+	}
+
+	@Test
+	public void testMultipleStatisticForNullPlayer() {
+		expectIllegalArgumentExceptionWithMessage("Player cannot be null.");
+		underTest.getStatisticForMultipleCategory(null, MultipleAchievements.KILLS, "skeleton");
+	}
+
+	@Test
+	public void testMultipleStatisticForNullCategory() {
+		expectIllegalArgumentExceptionWithMessage("Category cannot be null.");
+		underTest.getStatisticForMultipleCategory(UUID.randomUUID(), null, "skeleton");
+	}
+
+	@Test
+	public void testMultipleStatisticForEmptySubcategory() {
+		expectIllegalArgumentExceptionWithMessage("Sub-category cannot be empty.");
+		underTest.getStatisticForMultipleCategory(UUID.randomUUID(), MultipleAchievements.KILLS, "");
+	}
+
+	@Test
+	public void testAchievementDisplayName() {
+		expectIllegalArgumentExceptionWithMessage("Achievement Name cannot be empty.");
+		underTest.getDisplayNameForName("");
+	}
+
+	private void expectIllegalArgumentExceptionWithMessage(String message) {
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage(message);
+	}
+}

--- a/src/test/java/com/hm/achievement/db/SQLiteDatabaseNullSafetyTest.java
+++ b/src/test/java/com/hm/achievement/db/SQLiteDatabaseNullSafetyTest.java
@@ -59,7 +59,6 @@ public class SQLiteDatabaseNullSafetyTest extends SQLiteDatabaseTest {
     }
 
     @Test
-    @Ignore("Can be enabled later")
     public void testRegisterNullUUID() {
         registerAchievement(null, testAchievement, testAchievementMsg);
 
@@ -75,7 +74,6 @@ public class SQLiteDatabaseNullSafetyTest extends SQLiteDatabaseTest {
     }
 
     @Test
-    @Ignore("Can be enabled later")
     public void testGetMethodsForNullUUIDExceptions() {
         addNullUUIDtoDB();
 
@@ -87,21 +85,21 @@ public class SQLiteDatabaseNullSafetyTest extends SQLiteDatabaseTest {
     }
 
     private void addNullUUIDtoDB() {
-        String sql = "REPLACE INTO achievements VALUES ('" + null + "',?,?,?)";
+        String sql = "REPLACE INTO achievements VALUES (?,?,?,?)";
 
         ((SQLWriteOperation) () -> {
             Connection conn = db.getSQLConnection();
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
-                ps.setString(1, testAchievement);
-                ps.setString(2, testAchievementMsg);
-                ps.setDate(3, new Date(System.currentTimeMillis()));
+            	ps.setObject(1, null);
+                ps.setString(2, testAchievement);
+                ps.setString(3, testAchievementMsg);
+                ps.setDate(4, new Date(System.currentTimeMillis()));
                 ps.execute();
             }
         }).executeOperation(db.pool, db.plugin.getLogger(), "registering an achievement with null UUID");
     }
 
     @Test
-    @Ignore("Can be enabled later")
     public void testRegisterNullAch() {
         registerAchievement(testUUID, null, testAchievementMsg);
 
@@ -111,12 +109,11 @@ public class SQLiteDatabaseNullSafetyTest extends SQLiteDatabaseTest {
         System.out.println("Saved Achievements: " + list);
         System.out.println("Saved Achievements Map: " + map);
 
-        assertTrue("An achievement with name 'null' was saved", list.isEmpty());
-        assertEquals(0, (int) map.getOrDefault(testUUID, 0));
+        assertEquals(3, list.size());
+        assertEquals(1, (int) map.getOrDefault(testUUID, 0));
     }
 
     @Test
-    @Ignore("Can be enabled later")
     public void testRegisterNullMsg() {
         registerAchievement(testUUID, testAchievement, null);
 


### PR DESCRIPTION
This pull request is a follow up to #286. 

I have enabled the ignored tests in _SQLiteDatabaseNullSafetyTest.java_. After thinking about the `testRegisterNullAch` scenario again, I think the plugin should carry on and not block the achievement registration and have consequently slightly modified the test to reflect this. If a user calls the database methods directly without going through the API, I'm assuming he knows what he's doing and should be prepared to cope with the consequences. Possibly someone might want to extend the plugin and register some sort of meta-achievement without any _Name_. 

The UUIDs are now set as parameters in the _PreparedStatements_. This is safer, cleaner and more consistent. If a null UUID is passed in, it will now be persisted as `NULL` in the database, rather than a string with value `"null"`, which was poor behaviour.

I have added some simple validation to the API layer. When users go through the provided API, they should do sensible things, and if bogus parameters are passed in, the plugin will throw an exception explaining the cause.

@Rsl1122 as you were involved in the discussions and writing some of the tests, would you like to look at this? 👍 
