### PR TITLE
Allow tracking of multiple types on single achievement (#92)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,57 +69,9 @@ local.properties
 
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
-# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff:
-.idea/misc.xml
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/dictionaries
-.idea/vcs.xml
-.idea/jsLibraryMappings.xml
-
-# Sensitive or high-churn files:
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
-# Gradle:
-.idea/gradle.xml
-.idea/libraries
-
-# Mongo Explorer plugin:
-.idea/mongoSettings.xml
-
-## File-based project format:
-*.iws
-
-## Plugin-specific files:
-
-# IntelliJ
-/out/
-
-# mpeltonen/sbt-idea plugin
-.idea_modules/
-
-# JIRA plugin
-atlassian-ide-plugin.xml
-
-# Crashlytics plugin (for Android Studio and IntelliJ)
-com_crashlytics_export_strings.xml
-crashlytics.properties
-crashlytics-build.properties
-fabric.properties
-
-### Intellij Patch ###
-# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
-
-# *.iml
-# modules.xml
-
+AdvancedAchievements.iml
+.idea/
 
 ### NetBeans ###
 nbproject/private/

--- a/src/main/java/com/hm/achievement/listener/statistics/AbstractListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/AbstractListener.java
@@ -3,7 +3,11 @@ package com.hm.achievement.listener.statistics;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
@@ -103,4 +107,13 @@ public abstract class AbstractListener extends StatisticIncreaseHandler implemen
 
 		return availableSpace;
 	}
+
+	Set<String> findAdvancementsByCategoryAndName(MultipleAchievements category, String identifierStr) {
+		Pattern identifier = Pattern.compile(String.format("%s.%s", category, identifierStr));
+		return mainConfig.getKeys(false).stream()
+				.filter(key -> identifier.matcher(key).find())
+				.map(string -> string.replaceFirst(String.format("%s.", category), ""))
+				.collect(Collectors.toSet());
+	}
+
 }

--- a/src/main/java/com/hm/achievement/listener/statistics/AbstractListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/AbstractListener.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.Sets;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -108,11 +109,16 @@ public abstract class AbstractListener extends StatisticIncreaseHandler implemen
 		return availableSpace;
 	}
 
-	Set<String> findAdvancementsByCategoryAndName(MultipleAchievements category, String identifierStr) {
-		Pattern identifier = Pattern.compile(String.format("%s.%s", category, identifierStr));
-		return mainConfig.getKeys(false).stream()
-				.filter(key -> identifier.matcher(key).find())
-				.map(string -> string.replaceFirst(String.format("%s.", category), ""))
+	Set<String> findAdvancementsByCategoryAndName(MultipleAchievements category, String identifier) {
+		if (!mainConfig.isConfigurationSection(category.toString())) return Sets.newHashSet();
+
+		return mainConfig.getConfigurationSection(category.toString()).getKeys(false).stream()
+				.filter(key -> {
+					Pattern pattern = Pattern.compile(key, Pattern.CASE_INSENSITIVE);
+					//System.out.println("id: \"" + identifier + "\"; key: " + key + "; pattern: "
+					//		+ pattern.toString() +  "; matcher status: " + pattern.matcher(identifier).find());
+					return pattern.matcher(identifier).find();
+				})
 				.collect(Collectors.toSet());
 	}
 

--- a/src/main/java/com/hm/achievement/listener/statistics/BreaksListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/BreaksListener.java
@@ -2,6 +2,7 @@ package com.hm.achievement.listener.statistics;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -81,13 +82,10 @@ public class BreaksListener extends AbstractListener {
 		if (!player.hasPermission(category.toPermName() + '.' + blockName)) {
 			return;
 		}
-		if (mainConfig.isConfigurationSection(
-				category + "." + blockName + ':' + block.getState().getData().toItemStack().getDurability())) {
-			blockName += ":" + block.getState().getData().toItemStack().getDurability();
-		} else if (!mainConfig.isConfigurationSection(category + "." + blockName)) {
-			return;
-		}
 
-		updateStatisticAndAwardAchievementsIfAvailable(player, category, blockName, 1);
+		Set<String> foundAchievements = findAdvancementsByCategoryAndName(
+				category, blockName + ':' + block.getState().getData().toItemStack().getDurability());
+		foundAchievements.addAll(findAdvancementsByCategoryAndName(category, blockName));
+		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category, achievement, 1));
 	}
 }

--- a/src/main/java/com/hm/achievement/listener/statistics/BreedingListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/BreedingListener.java
@@ -2,6 +2,7 @@ package com.hm.achievement.listener.statistics;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -51,7 +52,7 @@ public class BreedingListener extends AbstractListener {
 
 		Entity entity = event.getMother();
 
-		if (!(entity instanceof LivingEntity)) {
+		if (entity == null) {
 			return;
 		}
 
@@ -59,9 +60,11 @@ public class BreedingListener extends AbstractListener {
 
 		MultipleAchievements category = MultipleAchievements.BREEDING;
 
-		if (mainConfig.isConfigurationSection(category + "." + mobName)
-				&& player.hasPermission(category.toPermName() + '.' + mobName)) {
-			updateStatisticAndAwardAchievementsIfAvailable(player, category, mobName, 1);
+		if (!player.hasPermission(category.toPermName() + '.' + mobName)) {
+			return;
 		}
+
+		Set<String> foundAchievements = findAdvancementsByCategoryAndName(category, mobName);
+		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category, achievement, 1));
 	}
 }

--- a/src/main/java/com/hm/achievement/listener/statistics/KillsListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/KillsListener.java
@@ -2,11 +2,13 @@ package com.hm.achievement.listener.statistics;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import com.google.common.collect.Sets;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -67,19 +69,19 @@ public class KillsListener extends AbstractListener {
 
 		MultipleAchievements category = MultipleAchievements.KILLS;
 
-		if (mainConfig.isConfigurationSection(category + "." + mobName)
-				&& player.hasPermission(category.toPermName() + '.' + mobName)) {
-			updateStatisticAndAwardAchievementsIfAvailable(player, category, mobName, 1);
+		Set<String> foundAchievements = Sets.newHashSet();
+
+		if (player.hasPermission(category.toPermName() + '.' + mobName)) {
+			foundAchievements.addAll(findAdvancementsByCategoryAndName(category, mobName));
 		}
 
 		if (entity instanceof Player) {
-			String specificPlayer = "specificplayer-" + ((Player) entity).getUniqueId().toString().toLowerCase();
-			if (!mainConfig.isConfigurationSection(category + "." + specificPlayer)
-					|| !player.hasPermission(category.toPermName() + '.' + specificPlayer)) {
-				return;
+			String specificPlayer = "specificplayer-" + entity.getUniqueId().toString().toLowerCase();
+			if (player.hasPermission(category.toPermName() + '.' + specificPlayer)) {
+				foundAchievements.addAll(findAdvancementsByCategoryAndName(category, specificPlayer));
 			}
-
-			updateStatisticAndAwardAchievementsIfAvailable(player, category, specificPlayer, 1);
 		}
+
+		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category, achievement, 1));
 	}
 }

--- a/src/main/java/com/hm/achievement/listener/statistics/PlacesListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/PlacesListener.java
@@ -2,6 +2,7 @@ package com.hm.achievement.listener.statistics;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -50,13 +51,10 @@ public class PlacesListener extends AbstractListener {
 		if (!player.hasPermission(category.toPermName() + '.' + blockName)) {
 			return;
 		}
-		if (mainConfig.isConfigurationSection(
-				category + "." + blockName + ':' + block.getState().getData().toItemStack(0).getDurability())) {
-			blockName += ":" + block.getState().getData().toItemStack(0).getDurability();
-		} else if (!mainConfig.isConfigurationSection(category + "." + blockName)) {
-			return;
-		}
 
-		updateStatisticAndAwardAchievementsIfAvailable(player, category, blockName, 1);
+		Set<String> foundAchievements = findAdvancementsByCategoryAndName(
+				category, blockName + ':' + block.getState().getData().toItemStack(0).getDurability());
+		foundAchievements.addAll(findAdvancementsByCategoryAndName(category, blockName));
+		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category, achievement, 1));
 	}
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -284,6 +284,11 @@ Breaks:
       Message: "&cYou have collected 10 red sand blocks!"
       Name: break_10_sand1
       DisplayName: Red Sand Fan
+  "[sand|sand:1]":
+    32:
+      Message: "&cYou have collected half a stack of any sand! Woo!"
+      Name: break_32_sand_any
+      DisplayName: "Sand Dude"
   stone:
     1:
       Message: "&1The first time you went mining!"


### PR DESCRIPTION
Hey!

This PR adds support for using Regexes in achievement types. This has not been implemented on PlayerCommands or Crafts because they are so complicated I do not want to break them, however everything else that supports types should work.

A sample achievement is included. (however it is useless as it would be granted anyways but it demos the feature).

closes #92 