### PR TITLE
Extend tracking of multiple types (#341)

### DIFF
--- a/src/main/java/com/hm/achievement/listener/statistics/AbstractListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/AbstractListener.java
@@ -109,12 +109,13 @@ public abstract class AbstractListener extends StatisticIncreaseHandler implemen
 
 	/**
 	 * Returns all achievements that match the provided identifier.
+	 * 
 	 * @param category the category to search from
 	 * @param identifier the identifier to match
 	 * @return all matched achievements
 	 * @author tassu
 	 */
-	Set<String> findAdvancementsByCategoryAndName(MultipleAchievements category, String identifier) {
+	Set<String> findAchievementsByCategoryAndName(MultipleAchievements category, String identifier) {
 		return mainConfig.getShallowKeys(category.toString()).stream()
 				.filter(keys -> ArrayUtils.contains(StringUtils.split(keys, '|'), identifier))
 				.collect(Collectors.toSet());

--- a/src/main/java/com/hm/achievement/listener/statistics/BreaksListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/BreaksListener.java
@@ -83,9 +83,10 @@ public class BreaksListener extends AbstractListener {
 			return;
 		}
 
-		Set<String> foundAchievements = findAdvancementsByCategoryAndName(
+		Set<String> foundAchievements = findAchievementsByCategoryAndName(
 				category, blockName + ':' + block.getState().getData().toItemStack().getDurability());
-		foundAchievements.addAll(findAdvancementsByCategoryAndName(category, blockName));
-		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category, achievement, 1));
+		foundAchievements.addAll(findAchievementsByCategoryAndName(category, blockName));
+		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category,
+				achievement, 1));
 	}
 }

--- a/src/main/java/com/hm/achievement/listener/statistics/BreedingListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/BreedingListener.java
@@ -54,7 +54,8 @@ public class BreedingListener extends AbstractListener {
 			return;
 		}
 
-		Set<String> foundAchievements = findAdvancementsByCategoryAndName(category, mobName);
-		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category, achievement, 1));
+		Set<String> foundAchievements = findAchievementsByCategoryAndName(category, mobName);
+		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category,
+				achievement, 1));
 	}
 }

--- a/src/main/java/com/hm/achievement/listener/statistics/CraftsListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/CraftsListener.java
@@ -2,6 +2,7 @@ package com.hm.achievement.listener.statistics;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -57,11 +58,9 @@ public class CraftsListener extends AbstractListener {
 		if (!player.hasPermission(category.toPermName() + '.' + craftName)) {
 			return;
 		}
-		if (mainConfig.isConfigurationSection(category + "." + craftName + ':' + item.getDurability())) {
-			craftName += ":" + item.getDurability();
-		} else if (!mainConfig.isConfigurationSection(category + "." + craftName)) {
-			return;
-		}
+
+		Set<String> foundAchievements = findAchievementsByCategoryAndName(category, craftName + ":" + item.getDurability());
+		foundAchievements.addAll(findAchievementsByCategoryAndName(category, craftName));
 
 		int eventAmount = event.getCurrentItem().getAmount();
 		if (event.isShiftClick()) {
@@ -82,6 +81,8 @@ public class CraftsListener extends AbstractListener {
 			}
 		}
 
-		updateStatisticAndAwardAchievementsIfAvailable(player, category, craftName, eventAmount);
+		int incrementValue = eventAmount; // Effectively final variable needed.
+		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category,
+				craftName, incrementValue));
 	}
 }

--- a/src/main/java/com/hm/achievement/listener/statistics/KillsListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/KillsListener.java
@@ -65,16 +65,17 @@ public class KillsListener extends AbstractListener {
 		Set<String> foundAchievements = new HashSet<>();
 
 		if (player.hasPermission(category.toPermName() + '.' + mobName)) {
-			foundAchievements.addAll(findAdvancementsByCategoryAndName(category, mobName));
+			foundAchievements.addAll(findAchievementsByCategoryAndName(category, mobName));
 		}
 
 		if (entity instanceof Player) {
 			String specificPlayer = "specificplayer-" + entity.getUniqueId().toString().toLowerCase();
 			if (player.hasPermission(category.toPermName() + '.' + specificPlayer)) {
-				foundAchievements.addAll(findAdvancementsByCategoryAndName(category, specificPlayer));
+				foundAchievements.addAll(findAchievementsByCategoryAndName(category, specificPlayer));
 			}
 		}
 
-		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category, achievement, 1));
+		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category,
+				achievement, 1));
 	}
 }

--- a/src/main/java/com/hm/achievement/listener/statistics/PlacesListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/PlacesListener.java
@@ -52,9 +52,10 @@ public class PlacesListener extends AbstractListener {
 			return;
 		}
 
-		Set<String> foundAchievements = findAdvancementsByCategoryAndName(
+		Set<String> foundAchievements = findAchievementsByCategoryAndName(
 				category, blockName + ':' + block.getState().getData().toItemStack(0).getDurability());
-		foundAchievements.addAll(findAdvancementsByCategoryAndName(category, blockName));
-		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category, achievement, 1));
+		foundAchievements.addAll(findAchievementsByCategoryAndName(category, blockName));
+		foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player, category,
+				achievement, 1));
 	}
 }

--- a/src/main/java/com/hm/achievement/listener/statistics/PlayerCommandsListener.java
+++ b/src/main/java/com/hm/achievement/listener/statistics/PlayerCommandsListener.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -48,7 +49,9 @@ public class PlayerCommandsListener extends AbstractListener {
 			for (String equivalentCommand : equivalentCommands) {
 				if (equivalentCommand.startsWith(prefix)) {
 					if (player.hasPermission(category.toPermName() + '.' + StringUtils.deleteWhitespace(prefix))) {
-						updateStatisticAndAwardAchievementsIfAvailable(player, category, prefix, 1);
+						Set<String> foundAchievements = findAchievementsByCategoryAndName(category, prefix);
+						foundAchievements.forEach(achievement -> updateStatisticAndAwardAchievementsIfAvailable(player,
+								category, prefix, 1));
 					}
 					return;
 				}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -284,6 +284,8 @@ Breaks:
       Message: "&cYou have collected 10 red sand blocks!"
       Name: break_10_sand1
       DisplayName: Red Sand Fan
+  # Use the following construct to track multiple types. Note that if ever you add/remove a type grouped to others with |,
+  # progress for this sub-category group will start back at 0.
   sand|sand:1:
     32:
       Message: "&cYou have collected half a stack of any sand! Woo!"


### PR DESCRIPTION
I've added support for the _PlayerCommands_ and _Crafts_ categories. I've also made a few other changes such as renaming the method name from `findAdvancementsByCategoryAndName` to `findAchievementsByCategoryAndName`, running `mvn formatter:format` and adding a comment in _config.yml_ to warn users about the limitations of the current implementation of this feature.

@supertassu would you mind giving this a look? 😉 