### PR TITLE
Added support for lists in command reward displays. (closes #351)

### DIFF
--- a/src/main/java/com/hm/achievement/listener/PlayerAdvancedAchievementListener.java
+++ b/src/main/java/com/hm/achievement/listener/PlayerAdvancedAchievementListener.java
@@ -1,10 +1,8 @@
 package com.hm.achievement.listener;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -197,11 +195,11 @@ public class PlayerAdvancedAchievementListener implements Listener, Reloadable {
 	 * @param oxygen
 	 * @return all the reward texts to be displayed to the user
 	 */
-	private List<String> giveRewardsAndPrepareTexts(Player player, String[] commands, String commandMessage, ItemStack item,
+	private List<String> giveRewardsAndPrepareTexts(Player player, String[] commands, List<String> commandMessage, ItemStack item,
 			int money, int experience, int health, int oxygen) {
 		List<String> rewardTexts = new ArrayList<>();
 		if (commands != null && commands.length > 0) {
-			rewardTexts.add(rewardCommands(commands, commandMessage));
+			rewardTexts.addAll(rewardCommands(commands, commandMessage));
 		}
 		if (item != null) {
 			rewardTexts.add(rewardItem(player, item));
@@ -225,22 +223,22 @@ public class PlayerAdvancedAchievementListener implements Listener, Reloadable {
 	 * Executes player command rewards.
 	 *
 	 * @param commands
-	 * @param message
+	 * @param messages
 	 * @return the reward text to display to the player
 	 */
-	private String rewardCommands(String[] commands, String message) {
+	private List<String> rewardCommands(String[] commands, List<String> messages) {
 		for (String command : commands) {
 			advancedAchievements.getServer().dispatchCommand(advancedAchievements.getServer().getConsoleSender(), command);
 		}
 		if (!configRewardCommandNotif || langCommandReward.length() == 0) {
-			return "";
+			return new ArrayList<>();
 		}
 
-		if (message != null) {
-			return StringUtils.replace(langCustomMessageCommandReward, "MESSAGE", message);
+		if (messages != null) {
+			return messages.stream().map(message -> StringUtils.replace(langCustomMessageCommandReward, "MESSAGE", message)).collect(Collectors.toList());
 		}
 
-		return langCommandReward;
+		return Collections.singletonList(langCommandReward);
 	}
 
 	/**

--- a/src/main/java/com/hm/achievement/utils/PlayerAdvancedAchievementEvent.java
+++ b/src/main/java/com/hm/achievement/utils/PlayerAdvancedAchievementEvent.java
@@ -6,6 +6,8 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.List;
+
 /**
  * Class representing an event fired when a player receives an achievement.
  * 
@@ -20,7 +22,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 	private final String name;
 	private final String displayName;
 	private final String message;
-	private final String commandMessage;
+	private final List<String> commandMessage;
 	private final String[] commandRewards;
 	private final ItemStack itemReward;
 	private final int moneyReward;
@@ -31,8 +33,8 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 	private boolean cancelled;
 
 	private PlayerAdvancedAchievementEvent(Player receiver, String name, String displayName, String message,
-			String commandMessage, String[] commandRewards, ItemStack itemReward, int moneyReward, int experienceReward,
-			int maxHealthReward, int maxOxygenReward) {
+	                                       List<String> commandMessage, String[] commandRewards, ItemStack itemReward, int moneyReward, int experienceReward,
+	                                       int maxHealthReward, int maxOxygenReward) {
 		player = receiver;
 		this.name = name;
 		this.displayName = displayName;
@@ -82,7 +84,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 		return message;
 	}
 
-	public String getCommandMessage() {
+	public List<String> getCommandMessage() {
 		return commandMessage;
 	}
 
@@ -116,7 +118,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 		private String name;
 		private String displayName;
 		private String message;
-		private String commandMessage;
+		private List<String> commandMessage;
 		private String[] commandRewards;
 		private ItemStack itemReward;
 		private int moneyReward;
@@ -144,7 +146,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 			return this;
 		}
 
-		public PlayerAdvancedAchievementEventBuilder commandMessage(String commandMessage) {
+		public PlayerAdvancedAchievementEventBuilder commandMessage(List<String> commandMessage) {
 			this.commandMessage = commandMessage;
 			return this;
 		}

--- a/src/main/java/com/hm/achievement/utils/PlayerAdvancedAchievementEvent.java
+++ b/src/main/java/com/hm/achievement/utils/PlayerAdvancedAchievementEvent.java
@@ -10,9 +10,8 @@ import java.util.List;
 
 /**
  * Class representing an event fired when a player receives an achievement.
- * 
- * @author Pyves
  *
+ * @author Pyves
  */
 public class PlayerAdvancedAchievementEvent extends Event implements Cancellable {
 

--- a/src/main/java/com/hm/achievement/utils/RewardParser.java
+++ b/src/main/java/com/hm/achievement/utils/RewardParser.java
@@ -1,6 +1,7 @@
 package com.hm.achievement.utils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -81,7 +82,7 @@ public class RewardParser implements Reloadable {
 	/**
 	 * Constructs the listing of an achievement's rewards with strings coming from language file.
 	 *
-	 * @param path
+	 * @param path achievement path
 	 * @return type(s) of the achievement reward as an array of strings
 	 */
 	public List<String> getRewardListing(String path) {
@@ -120,8 +121,8 @@ public class RewardParser implements Reloadable {
 
 		if (keyNames.contains(path + ".Command")) {
 			if (mainConfig.isConfigurationSection(path + ".Command") && keyNames.contains(path + ".Command.Display")) {
-				String message = getCustomCommandMessage(path);
-				rewardTypes.add(message);
+				List<String> messages = getCustomCommandMessage(path);
+				rewardTypes.addAll(messages);
 			} else {
 				rewardTypes.add(langListRewardCommand);
 			}
@@ -132,7 +133,7 @@ public class RewardParser implements Reloadable {
 	/**
 	 * Returns name of currency depending on amount.
 	 *
-	 * @param amount
+	 * @param amount achievement configuration path
 	 * @return the name of the currency
 	 */
 	public String getCurrencyName(int amount) {
@@ -142,7 +143,7 @@ public class RewardParser implements Reloadable {
 	/**
 	 * Returns the name of an item reward, in a readable format.
 	 *
-	 * @param item
+	 * @param item the item reward
 	 * @return the item name
 	 */
 	public String getItemName(ItemStack item) {
@@ -161,8 +162,8 @@ public class RewardParser implements Reloadable {
 	 * Extracts the money, experience, increased max health or increased max oxygen rewards amount from the
 	 * configuration.
 	 *
-	 * @param path
-	 * @param type
+	 * @param path achievement configuration path
+	 * @param type reward type
 	 * @return the reward amount
 	 */
 	public int getRewardAmount(String path, String type) {
@@ -173,7 +174,7 @@ public class RewardParser implements Reloadable {
 	/**
 	 * Returns an item reward for a given achievement (specified in configuration file).
 	 *
-	 * @param path
+	 * @param path achievement configuration path
 	 * @return ItemStack object corresponding to the reward
 	 */
 	public ItemStack getItemReward(String path) {
@@ -221,8 +222,8 @@ public class RewardParser implements Reloadable {
 	/**
 	 * Extracts the list of commands to be executed as rewards.
 	 *
-	 * @param path
-	 * @param player
+	 * @param path achievement configuration path
+	 * @param player the player to parse commands for
 	 * @return the array containing the commands to be performed as a reward
 	 */
 	public String[] getCommandRewards(String path, Player player) {
@@ -243,22 +244,27 @@ public class RewardParser implements Reloadable {
 	/**
 	 * Extracts custom command message from config. Might be null.
 	 *
-	 * @param path
+	 * @param path achievement configuration path
 	 * @return the custom command message (null if not present)
 	 * @author tassu
 	 */
-	public String getCustomCommandMessage(String path) {
+	public List<String> getCustomCommandMessage(String path) {
 		if (!mainConfig.isConfigurationSection(path + ".Command")) {
 			return null;
 		}
 
-		return mainConfig.getString(path + ".Command.Display");
+		if (mainConfig.isList(path + ".Command.Display")) {
+			return mainConfig.getStringList(path + ".Command.Display");
+		}
+
+
+		return Collections.singletonList(mainConfig.getString(path + ".Command.Display"));
 	}
 
 	/**
 	 * Extracts the item reward amount from the configuration.
 	 *
-	 * @param path
+	 * @param path achievement configuration path
 	 * @return the amount for an item reward
 	 */
 	private int getItemAmount(String path) {
@@ -286,7 +292,7 @@ public class RewardParser implements Reloadable {
 	/**
 	 * Extracts the item reward custom name from the configuration.
 	 *
-	 * @param path
+	 * @param path achievement configuration path
 	 * @return the custom name for an item reward
 	 */
 	private String getItemName(String path) {

--- a/src/main/java/com/hm/achievement/utils/RewardParser.java
+++ b/src/main/java/com/hm/achievement/utils/RewardParser.java
@@ -257,7 +257,6 @@ public class RewardParser implements Reloadable {
 			return mainConfig.getStringList(path + ".Command.Display");
 		}
 
-
 		return Collections.singletonList(mainConfig.getString(path + ".Command.Display"));
 	}
 


### PR DESCRIPTION
Hey!

This PR adds support for lists in custom command reward display names. Forgot to add an example achievement but tested it on my dev server and worked just fine. Also, if you give it a empty list (`Display: []`) it just does not show it.

Signed-off-by: Tassu <git@tassu.me>