### PR TITLE
Fixed formatter configuration for multi-modular Maven project

### DIFF
--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/FileUpdater.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/FileUpdater.java
@@ -219,8 +219,8 @@ public class FileUpdater {
 
 		// Iterate through all Lang implementation keys & default values
 		Arrays.stream(new Lang[][] { CmdLang.values(), HelpLang.values(), HelpLang.Hover.values(), InfoLang.values(),
-			GuiLang.values(), ListenerLang.values(), RewardLang.values(), NormalAchievements.values(),
-			MultipleAchievements.values() }).flatMap(Arrays::stream).forEach(language -> updateLang(lang, language));
+				GuiLang.values(), ListenerLang.values(), RewardLang.values(), NormalAchievements.values(),
+				MultipleAchievements.values() }).flatMap(Arrays::stream).forEach(language -> updateLang(lang, language));
 
 		// Not found in Enums (Possibly unused)
 		updateSetting(lang, "list-custom", "Custom Categories");

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/ConnectionsListener.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/ConnectionsListener.java
@@ -97,7 +97,7 @@ public class ConnectionsListener extends AbstractListener implements Cleanable {
 				// In addition to the usual reception conditions, check that the player is still connected and that
 				// another runnable hasn't already done the work (even though this method is intended to run once per
 				// player per connection instance, it might happen with some server settings).
-				if (shouldIncreaseBeTakenIntoAccount(player, NormalAchievements.CONNECTIONS)  && player.isOnline()
+				if (shouldIncreaseBeTakenIntoAccount(player, NormalAchievements.CONNECTIONS) && player.isOnline()
 						&& !playersConnectionProcessed.contains(player.getUniqueId())) {
 					handleConnectionAchievements(player);
 					// Ran successfully to completion: no need to re-run while player is connected.

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/placeholder/AchievementPlaceholderHook.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/placeholder/AchievementPlaceholderHook.java
@@ -33,8 +33,8 @@ public class AchievementPlaceholderHook extends PlaceholderExpansion {
 
 	@Inject
 	public AchievementPlaceholderHook(AdvancedAchievements advancedAchievements,
-				@Named("main") CommentedYamlConfiguration mainConfig,
-                CacheManager cacheManager, Set<String> disabledCategories, Map<String, String> achievementsAndDisplayNames) {
+			@Named("main") CommentedYamlConfiguration mainConfig,
+			CacheManager cacheManager, Set<String> disabledCategories, Map<String, String> achievementsAndDisplayNames) {
 		this.advancedAchievements = advancedAchievements;
 		this.mainConfig = mainConfig;
 		this.cacheManager = cacheManager;

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
 			<plugin>
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
-				<version>2.7.1</version>
+				<version>2.7.4</version>
 				<configuration>
-					<configFile>${project.basedir}/formatter-config.xml</configFile>
+					<configFile>${project.basedir}/../formatter-config.xml</configFile>
 					<compilerSource>${java.version}</compilerSource>
 					<compilerCompliance>${java.version}</compilerCompliance>
 					<compilerTargetPlatform>${java.version}</compilerTargetPlatform>


### PR DESCRIPTION
The formatter-maven-plugin was no longer working since this project was broken down into several modules in 246a0e5def495bcbe2de36d2f80ead9599ddaef6. The problem has since then been addressed in more recent versions of the plugin, see [this issue](https://github.com/revelc/formatter-maven-plugin/issues/261) for more information.

This pull request makes sure everything is up to date and properly set up.