### PR TITLE
Add empty categories to disabled categories when parsing the config.

### DIFF
--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
@@ -64,7 +64,7 @@ public class ConfigurationParser {
 	/**
 	 * Loads the files and populates common data structures used in other parts of the plugin. Performs basic validation
 	 * on the achievements.
-	 * 
+	 *
 	 * @throws PluginLoadError
 	 */
 	public void loadAndParseConfiguration() throws PluginLoadError {
@@ -76,13 +76,13 @@ public class ConfigurationParser {
 		parseHeader();
 		parseDisabledCategories();
 		parseAchievements();
+		logLoadingMessages();
 	}
 
 	/**
 	 * Loads and backs up a configuration file.
-	 * 
+	 *
 	 * @param configuration
-	 * 
 	 * @throws PluginLoadError
 	 */
 	private void loadAndBackupConfiguration(CommentedYamlConfiguration configuration) throws PluginLoadError {
@@ -168,7 +168,7 @@ public class ConfigurationParser {
 	/**
 	 * Goes through all the achievements for non-disabled categories. Populates relevant data structures and performs
 	 * basic validation. Logs some statistics.
-	 * 
+	 *
 	 * @throws PluginLoadError
 	 */
 	private void parseAchievements() throws PluginLoadError {
@@ -176,18 +176,12 @@ public class ConfigurationParser {
 		sortedThresholds.clear();
 
 		// Enumerate Commands achievements.
-		if (!disabledCategories.contains("Commands")) {
-			for (String ach : mainConfig.getShallowKeys("Commands")) {
-				parseAchievement("Commands." + ach);
-			}
-		}
+		parseAchievements("Commands");
 
 		// Enumerate the normal achievements.
 		for (NormalAchievements category : NormalAchievements.values()) {
 			String categoryName = category.toString();
-			if (!disabledCategories.contains(categoryName)) {
-				parseAchievements(categoryName);
-			}
+			parseAchievements(categoryName);
 		}
 
 		// Enumerate the achievements with multiple categories.
@@ -199,26 +193,30 @@ public class ConfigurationParser {
 				}
 			}
 		}
-
-		int categories = NormalAchievements.values().length + MultipleAchievements.values().length + 1
-				- disabledCategories.size();
-		logger.info("Loaded " + achievementsAndDisplayNames.size() + " achievements in " + categories + " categories.");
-		if (disabledCategories.size() == 1) {
-			logger.info(disabledCategories.size() + " disabled category: " + disabledCategories.toString());
-		} else if (!disabledCategories.isEmpty()) {
-			logger.info(disabledCategories.size() + " disabled categories: " + disabledCategories.toString());
-		}
 	}
 
 	/**
 	 * Parses all achievements for a given category or category + subcategory. Populates the sortedThresholds map.
-	 * 
-	 * @param path
-	 * @throws PluginLoadError
+	 *
+	 * @param path category or category.subcategory
+	 * @throws PluginLoadError If an achievement fails to parse due to misconfiguration.
 	 */
 	private void parseAchievements(String path) throws PluginLoadError {
+		if (disabledCategories.contains(path)) {
+			return;
+		}
+
+		Set<String> keys = mainConfig.getShallowKeys(path);
+
+		// Disable category if no achievements exist
+		// Don't add multi-achievement categories to disabled categories (path has a .)
+		if (keys.isEmpty() && !path.contains(".")) {
+			disabledCategories.add(path);
+			return;
+		}
+
 		List<Long> thresholds = new ArrayList<>();
-		for (String threshold : mainConfig.getShallowKeys(path)) {
+		for (String threshold : keys) {
 			parseAchievement(path + "." + threshold);
 			thresholds.add(Long.valueOf(threshold));
 		}
@@ -228,9 +226,9 @@ public class ConfigurationParser {
 
 	/**
 	 * Performs validation for a single achievement and populates an entry in the achievementsAndDisplayNames map.
-	 * 
+	 *
 	 * @param path
-	 * @throws PluginLoadError
+	 * @throws PluginLoadError If the achievement fails to parse due to misconfiguration.
 	 */
 	private void parseAchievement(String path) throws PluginLoadError {
 		String achName = mainConfig.getString(path + ".Name");
@@ -241,6 +239,18 @@ public class ConfigurationParser {
 					"Duplicate achievement Name (" + achName + "). " + "Please ensure each Name is unique in config.yml.");
 		} else {
 			achievementsAndDisplayNames.put(achName, mainConfig.getString(path + ".DisplayName", ""));
+		}
+	}
+
+	private void logLoadingMessages() {
+		int disabledCategoryCount = disabledCategories.size();
+		int categories = NormalAchievements.values().length + MultipleAchievements.values().length + 1
+				- disabledCategoryCount;
+		logger.info("Loaded " + achievementsAndDisplayNames.size() + " achievements in " + categories + " categories.");
+		if (disabledCategoryCount == 1) {
+			logger.info(disabledCategoryCount + " disabled category: " + disabledCategories.toString());
+		} else if (!disabledCategories.isEmpty()) {
+			logger.info(disabledCategoryCount + " disabled categories: " + disabledCategories.toString());
 		}
 	}
 


### PR DESCRIPTION
> I would be inclined to enhance the ConfigurationParser in a separate commit and add any categories that have 0 achievements to disabledCategories. :wink:
> ~ PyvesB in #392

This does that.

Additionally it parses *Commands* category using `parseAchievements(String)` method - I don't know if having the Commands achievements in `sortedThresholds` causes issues, so this can be reverted if necessary.
