### PR TITLE
Add raids won category

### DIFF
--- a/advanced-achievements-api/src/main/java/com/hm/achievement/category/NormalAchievements.java
+++ b/advanced-achievements-api/src/main/java/com/hm/achievement/category/NormalAchievements.java
@@ -48,7 +48,8 @@ public enum NormalAchievements implements Category {
 	DISTANCEMINECART("DistanceMinecart", "list-distance-minecart", "Distance Travelled in a Minecart", "When a distance is traveled in a minecart."),
 	DISTANCEBOAT("DistanceBoat", "list-distance-boat", "Distance Travelled in a Boat", "When a distance is traveled in a boat."),
 	DISTANCEGLIDING("DistanceGliding", "list-distance-gliding", "Distance Travelled with Elytra", "When a distance is traveled with elytra."),
-	DISTANCELLAMA("DistanceLlama", "list-distance-llama", "Distance Travelled on a Llama", "When a distance is traveled on a llama.");
+	DISTANCELLAMA("DistanceLlama", "list-distance-llama", "Distance Travelled on a Llama", "When a distance is traveled on a llama."),
+	RAIDSWON("RaidsWon", "list-raids-won", "Raids Won", "When a raid is won.");
 
 	private static final Map<String, NormalAchievements> CATEGORY_NAMES_TO_ENUM = new HashMap<>();
 	static {

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/config/ConfigurationParser.java
@@ -181,6 +181,13 @@ public class ConfigurationParser {
 			logger.warning(
 					"The projectile hit event is not fully available in your server version, please add TargetsShot to the DisabledCategories list in config.yml.");
 		}
+		// Raids introduced in 1.14.
+		if (!disabledCategories.contains(NormalAchievements.RAIDSWON) && serverVersion < 14) {
+			disabledCategories.add(NormalAchievements.RAIDSWON);
+			logger.warning("Overriding configuration: disabling RaidsWon category.");
+			logger.warning(
+					"Raids are not available in your server version, please add RaidsWon to the DisabledCategories list in config.yml.");
+		}
 	}
 
 	/**

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/WinRaidListener.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/WinRaidListener.java
@@ -16,18 +16,20 @@ import java.util.Map;
 
 /**
  * Processes raid win event.
+ * 
  * @author Taavi Väänänen
  */
 @Singleton
 public class WinRaidListener extends AbstractListener {
-    @Inject
-    public WinRaidListener(@Named("main") CommentedYamlConfiguration mainConfig, int serverVersion,
-                          Map<String, List<Long>> sortedThresholds, CacheManager cacheManager, RewardParser rewardParser) {
-        super(NormalAchievements.RAIDSWON, mainConfig, serverVersion, sortedThresholds, cacheManager, rewardParser);
-    }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onRaidFinish(RaidFinishEvent event) {
-        event.getWinners().forEach(player -> updateStatisticAndAwardAchievementsIfAvailable(player, 1));
-    }
+	@Inject
+	public WinRaidListener(@Named("main") CommentedYamlConfiguration mainConfig, int serverVersion,
+			Map<String, List<Long>> sortedThresholds, CacheManager cacheManager, RewardParser rewardParser) {
+		super(NormalAchievements.RAIDSWON, mainConfig, serverVersion, sortedThresholds, cacheManager, rewardParser);
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	public void onRaidFinish(RaidFinishEvent event) {
+		event.getWinners().forEach(player -> updateStatisticAndAwardAchievementsIfAvailable(player, 1));
+	}
 }

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/WinRaidListener.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/WinRaidListener.java
@@ -1,0 +1,34 @@
+package com.hm.achievement.listener.statistics;
+
+import com.hm.achievement.category.NormalAchievements;
+import com.hm.achievement.db.CacheManager;
+import com.hm.achievement.utils.RewardParser;
+import com.hm.mcshared.file.CommentedYamlConfiguration;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.raid.RaidFinishEvent;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Processes raid win event.
+ * @author Taavi Väänänen
+ */
+@Singleton
+public class WinRaidListener extends AbstractListener {
+    @Inject
+    public WinRaidListener(@Named("main") CommentedYamlConfiguration mainConfig, int serverVersion,
+                          Map<String, List<Long>> sortedThresholds, CacheManager cacheManager, RewardParser rewardParser) {
+        super(NormalAchievements.RAIDSWON, mainConfig, serverVersion, sortedThresholds, cacheManager, rewardParser);
+        System.out.println("foo bar");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onRaidFinish(RaidFinishEvent event) {
+        event.getWinners().forEach(player -> updateStatisticAndAwardAchievementsIfAvailable(player, 1));
+    }
+}

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/WinRaidListener.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/WinRaidListener.java
@@ -24,7 +24,6 @@ public class WinRaidListener extends AbstractListener {
     public WinRaidListener(@Named("main") CommentedYamlConfiguration mainConfig, int serverVersion,
                           Map<String, List<Long>> sortedThresholds, CacheManager cacheManager, RewardParser rewardParser) {
         super(NormalAchievements.RAIDSWON, mainConfig, serverVersion, sortedThresholds, cacheManager, rewardParser);
-        System.out.println("foo bar");
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/module/ReloadableModule.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/module/ReloadableModule.java
@@ -50,6 +50,7 @@ import com.hm.achievement.listener.statistics.TargetsShotListener;
 import com.hm.achievement.listener.statistics.TradesListener;
 import com.hm.achievement.listener.statistics.TreasuresListener;
 import com.hm.achievement.listener.statistics.WaterBucketsListener;
+import com.hm.achievement.listener.statistics.WinRaidListener;
 import com.hm.achievement.runnable.AchieveDistanceRunnable;
 import com.hm.achievement.runnable.AchievePlayTimeRunnable;
 import com.hm.achievement.utils.RewardParser;
@@ -267,4 +268,8 @@ public abstract class ReloadableModule {
 	@Binds
 	@IntoSet
 	abstract Reloadable bindWaterBucketsListener(WaterBucketsListener waterBucketsListener);
+
+	@Binds
+	@IntoSet
+	abstract Reloadable bindsWinRaidListener(WinRaidListener winRaidListener);
 }

--- a/advanced-achievements-plugin/src/main/resources/config.yml
+++ b/advanced-achievements-plugin/src/main/resources/config.yml
@@ -729,6 +729,23 @@ Smelting:
     Message: 250 items smelt in a furnace!
     Name: smeltitems_250
     DisplayName: The Smelter
+
+# When a raid is won.
+RaidsWon:
+  1:
+    Goal: Win a raid.
+    Message: A raid won!
+    Name: raidswon_1
+    DisplayName: Accident or intentional?
+    Reward:
+      Item: emerald 8
+  10:
+    Goal: Win ten raids.
+    Message: Ten raids!
+    Name: raidswon_10
+    DisplayName: Village Protector
+    Reward:
+      Item: totem_of_undying 1
           
 #===========================OOOOOOO===========================#
 # VII-----------------------------------------------------VII #

--- a/advanced-achievements-plugin/src/main/resources/gui.yml
+++ b/advanced-achievements-plugin/src/main/resources/gui.yml
@@ -120,6 +120,8 @@ Commands:
   Item: bookshelf
 TargetsShot:
   Item: firework_star
+RaidsWon:
+  Item: emerald
 
 #============================================================#
 # +--------------------------------------------------------+ #

--- a/advanced-achievements-plugin/src/main/resources/lang.yml
+++ b/advanced-achievements-plugin/src/main/resources/lang.yml
@@ -190,6 +190,7 @@ list-smelting: "Items Smelt"
 list-commands: "Other Achievements"
 list-custom: "Custom Categories"
 list-targetsshot: "Targets Shot"
+list-raids-won: "Raids Won"
 
 # Related to /aach toggle.
 toggle-displayed: "You will now be notified when other players get achievements."

--- a/advanced-achievements-plugin/src/main/resources/plugin.yml
+++ b/advanced-achievements-plugin/src/main/resources/plugin.yml
@@ -221,6 +221,9 @@ permissions:
   achievement.count.custom:
     description: Allows custom statistics in database to increase.
     default: true
+  achievement.count.raidswon:
+    description: Allows raids won statistic in database to increase.
+    default: true
 # More granular permissions are available for the Breaks, Places, Crafts, Kills, Breeding, PlayerCommands, Custom and TargetsShot categories.
 # They depend on the sub-categories defined; for instance for stone breaks: achievement.count.breaks.stone
 # For PlayerCommands, use lower case without spaces nor the initial slash: achievement.count.playercommands.aachbook


### PR DESCRIPTION
ref #153.

It currently complains 
```
[22:00:46 ERROR]: [AdvancedAchievements] Plugin AdvancedAchievements v5.12.5 has failed to register events for class com.hm.achievement.listener.statistics.WinRaidListener because org/bukkit/event/raid/RaidFinishEvent does not exist.
```
when using version 1.13 or lower. It does not prevent startup, but still I'd like to fix that, however I have no idea how.

I have another PR coming so don't make a release just yet.