### PR TITLE
Process playtime achievement eligibility in parallel to speed up when there are a large number of players.

### DIFF
--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/runnable/AchievePlayTimeRunnable.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/runnable/AchievePlayTimeRunnable.java
@@ -56,7 +56,7 @@ public class AchievePlayTimeRunnable extends StatisticIncreaseHandler implements
 	@Override
 	public void run() {
 		long currentTime = System.currentTimeMillis();
-		Bukkit.getOnlinePlayers().stream().forEach(p -> updateTime(p, currentTime));
+		Bukkit.getOnlinePlayers().parallelStream().forEach(p -> updateTime(p, currentTime));
 		previousRunMillis = currentTime;
 	}
 


### PR DESCRIPTION
Fixes issue 687.