### PR TITLE
Add support for selectors in AbstractParsableCommand

### DIFF
--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/command/executable/AbstractParsableCommand.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/command/executable/AbstractParsableCommand.java
@@ -51,12 +51,12 @@ public abstract class AbstractParsableCommand extends AbstractCommand {
 	void onExecute(CommandSender sender, String[] args) {
 		String searchedName = args[args.length - 1];
 		Entity[] entities = CommandUtils.getTargets(sender, searchedName);
-		if(entities == null){
+		if (entities == null) {
 			sender.sendMessage(pluginHeader + langEntityNotPlayer);
 			return;
 		}
-		for(int i = 0; i < entities.length;i++){
-			if(entities[i]==null) {
+		for (int i = 0; i < entities.length; i++) {
+			if (entities[i] == null) {
 				sender.sendMessage(pluginHeader + StringUtils.replaceOnce(langPlayerOffline, "PLAYER", searchedName));
 				break;
 			}
@@ -86,23 +86,4 @@ public abstract class AbstractParsableCommand extends AbstractCommand {
 		}
 		return achievementName.toString();
 	}
-
-//	private boolean startsWithSelector(String arg) {
-//		List<String> selectors = Arrays.asList("@a", "@p", "@s", "@r");
-//		for(String selector : selectors) {
-//			if(arg.startsWith(selector)) return true;
-//		}
-//		return false;
-//
-//				String argsString = arg;
-//				for(int i = 2; i < args.length; i++) {
-//					argsString += " " + args[i];
-//				}
-//				//boolean opBefore = sender.isOp();//Only needed if Command should be useable by non-ops
-//				//sender.setOp(true);
-//				Bukkit.dispatchCommand(sender, "minecraft:execute " + args[0] + " ~ ~ ~ " + label + " self " + argsString);
-//				//sender.setOp(opBefore);
-//				return true;
-//		return false;
-//	}
 }

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/command/executable/AbstractParsableCommand.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/command/executable/AbstractParsableCommand.java
@@ -51,6 +51,10 @@ public abstract class AbstractParsableCommand extends AbstractCommand {
 	void onExecute(CommandSender sender, String[] args) {
 		String searchedName = args[args.length - 1];
 		Entity[] entities = CommandUtils.getTargets(sender, searchedName);
+		if(entities == null){
+			sender.sendMessage(pluginHeader + langEntityNotPlayer);
+			return;
+		}
 		for(int i = 0; i < entities.length;i++){
 			if(entities[i]==null) {
 				sender.sendMessage(pluginHeader + StringUtils.replaceOnce(langPlayerOffline, "PLAYER", searchedName));
@@ -59,7 +63,7 @@ public abstract class AbstractParsableCommand extends AbstractCommand {
 			try {
 				onExecuteForPlayer(sender, args, (Player) entities[i]);
 			} catch (ClassCastException e) {
-				sender.sendMessage(pluginHeader + langPlayerOffline);
+				sender.sendMessage(pluginHeader + langEntityNotPlayer);
 			}
 		}
 

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/command/executable/AbstractParsableCommand.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/command/executable/AbstractParsableCommand.java
@@ -1,8 +1,7 @@
 package com.hm.achievement.command.executable;
 
-import com.hm.achievement.utils.CommandUtils;
+import com.hm.achievement.command.external.CommandUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -10,9 +9,6 @@ import org.bukkit.entity.Player;
 import com.hm.achievement.lang.LangHelper;
 import com.hm.achievement.lang.command.CmdLang;
 import com.hm.mcshared.file.CommentedYamlConfiguration;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Abstract class in charge of factoring out common functionality for commands with more than one argument (/aach give,
@@ -60,13 +56,13 @@ public abstract class AbstractParsableCommand extends AbstractCommand {
 				sender.sendMessage(pluginHeader + StringUtils.replaceOnce(langPlayerOffline, "PLAYER", searchedName));
 				break;
 			}
-			try {
+			if (entities[i] instanceof Player) {
 				onExecuteForPlayer(sender, args, (Player) entities[i]);
-			} catch (ClassCastException e) {
-				sender.sendMessage(pluginHeader + langEntityNotPlayer);
+			} else {
+				sender.sendMessage(
+						pluginHeader + StringUtils.replaceOnce(langEntityNotPlayer, "ENTITY", entities[i].getType().name()));
 			}
 		}
-
 	}
 
 	/**

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/command/external/CommandUtils.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/command/external/CommandUtils.java
@@ -1,23 +1,4 @@
-package com.hm.achievement.utils;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
-
-import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
-import org.bukkit.Location;
-import org.bukkit.World;
-import org.bukkit.command.BlockCommandSender;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Damageable;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.HumanEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.minecart.CommandMinecart;
-import org.bukkit.scoreboard.Objective;
-import org.bukkit.scoreboard.Team;
+package com.hm.achievement.command.external;
 
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -43,7 +24,6 @@ public class CommandUtils {
 	/**
 	 * The CommandUtils class is used for selector support in commands (@p, @a etc.) Originally made by ZombieStriker
 	 * https://github.com/ZombieStriker/PsudoCommands/blob/master/src/me/zombie_striker/psudocommands/CommandUtils.java
-	 * https://github.com/ZombieStriker/CommandUtils/blob/master/src/CommandUtils.java
 	 */
 
 	/**

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/command/external/LICENSE
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/command/external/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/lang/command/CmdLang.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/lang/command/CmdLang.java
@@ -13,6 +13,7 @@ public enum CmdLang implements Lang {
 	NO_PERMISSIONS("You do not have the permission to do this."),
 	INVALID_COMMAND("Invalid command. Please type /aach to display the command help."),
 	PLAYER_OFFLINE("The player PLAYER is offline!"),
+	NOT_A_PLAYER("You cannot give achievements to entities other than players!"),
 	PLAYER_RANK("Current rank:"),
 	NOT_RANKED("You are currently not ranked for this period."),
 	// AddCommand

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/lang/command/CmdLang.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/lang/command/CmdLang.java
@@ -13,7 +13,7 @@ public enum CmdLang implements Lang {
 	NO_PERMISSIONS("You do not have the permission to do this."),
 	INVALID_COMMAND("Invalid command. Please type /aach to display the command help."),
 	PLAYER_OFFLINE("The player PLAYER is offline!"),
-	NOT_A_PLAYER("You cannot give achievements to entities other than players!"),
+	NOT_A_PLAYER("You cannot give achievements to ENTITY, it is not a player!"),
 	PLAYER_RANK("Current rank:"),
 	NOT_RANKED("You are currently not ranked for this period."),
 	// AddCommand

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/CommandUtils.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/CommandUtils.java
@@ -41,6 +41,13 @@ import java.util.concurrent.ThreadLocalRandom;
 public class CommandUtils {
 
     /**
+     * The CommandUtils class is used for selector support in commands (@p, @a etc.)
+     * Originally made by ZombieStriker
+     * https://github.com/ZombieStriker/PsudoCommands/blob/master/src/me/zombie_striker/psudocommands/CommandUtils.java
+     * https://github.com/ZombieStriker/CommandUtils/blob/master/src/CommandUtils.java
+     * */
+
+    /**
      * Use this if you are unsure if a player provided the "@a" tag. This will allow
      * multiple entities to be retrieved.
      * <p>

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/CommandUtils.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/CommandUtils.java
@@ -19,98 +19,152 @@ import org.bukkit.entity.minecart.CommandMinecart;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Team;
 
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.command.BlockCommandSender;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Damageable;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.minecart.CommandMinecart;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Team;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
 public class CommandUtils {
 
     /**
-     * Use this if you are unsure if a player provided the "@a" tag. This will
-     * allow multiple entities to be retrieved.
-     *
-     * This can return a null variable if no tags are included, or if a value
-     * for a tag does not exist (I.e if the tag [type=___] contains an entity
-     * that does not exist in the specified world)
-     *
+     * Use this if you are unsure if a player provided the "@a" tag. This will allow
+     * multiple entities to be retrieved.
+     * <p>
+     * This can return a null variable if no tags are included, or if a value for a
+     * tag does not exist (I.e if the tag [type=___] contains an entity that does
+     * not exist in the specified world)
+     * <p>
      * The may also be empty or null values at the end of the array. Once a null
      * value has been reached, you do not need to loop through any of the higher
      * indexes
-     *
+     * <p>
      * Currently supports the tags:
      *
-     * @p , @a , @e , @r
-     *
-     *    Currently supports the selectors: [type=] [r=] [rm=] [c=] [w=] [m=]
-     *    [name=] [l=] [lm=] [h=] [hm=] [rx=] [rxm=] [ry=] [rym=] [team=]
-     *    [score_---=] [score_---_min=]
-     *
-     *    All selectors can be inverted.
-     *
-     * @param sender The
-     *            command sender
-     * @param arg The
-     *            argument to test for
+     * @param arg    the argument that we are testing for
+     * @param sender the sender of the command
      * @return The entities that match the criteria
+     * @p , @a , @e , @r
+     * <p>
+     * Currently supports the selectors: [type=] [r=] [rm=] [c=] [w=] [m=]
+     * [name=] [l=] [lm=] [h=] [hm=] [rx=] [rxm=] [ry=] [rym=] [team=]
+     * [score_---=] [score_---_min=] [x] [y] [z] [limit=] [x_rotation] [y_rotation]
+     * <p>
+     * All selectors can be inverted.
      */
     public static Entity[] getTargets(CommandSender sender, String arg) {
-        Entity[] ents = null;
+        Entity[] ents;
         Location loc = null;
         if (sender instanceof Player) {
             loc = ((Player) sender).getLocation();
         } else if (sender instanceof BlockCommandSender) {
-            loc = ((BlockCommandSender) sender).getBlock().getLocation();
+            // Center of block.
+            loc = ((BlockCommandSender) sender).getBlock().getLocation().add(0.5, 0, 0.5);
         } else if (sender instanceof CommandMinecart) {
             loc = ((CommandMinecart) sender).getLocation();
         }
-        if (arg.startsWith("@a")) {
-            if (loc != null) {
-                int maxEnts = 0;
-                for (World w : getAcceptedWorlds(loc, arg))
-                    maxEnts += w.getEntities().size();
-                ents = new Entity[maxEnts];
-                int id = 0;
-                int C = getC(arg);
-                World world3 = null;
+        String[] tags = getTags(arg);
 
-                for (World w : getAcceptedWorlds(loc, arg)) {
-                    List<Entity> ea = w.getEntities();
-                    for (int i = 0; i < w.getEntities().size(); i++) {
-                        if (world3 == null || !world3.equals(w)) {
-                            world3 = w;
-                        }
-                        if (id >= C)
-                            break;
-                        Entity e = ea.get(i);
-                        boolean good = true;
-                        for (int b = 0; b < getTags(arg).length; b++) {
-                            if (!canBeAccepted(getTags(arg)[b], e, loc)) {
-                                good = false;
-                                break;
-                            }
-                        }
-                        if (good) {
-                            ents[id] = e;
-                            id++;
-                        }
+        // prefab fix
+        for (String s : tags) {
+            if (hasTag(SelectorType.X, s)) {
+                loc.setX(getInt(s));
+            } else if (hasTag(SelectorType.Y, s)) {
+                loc.setY(getInt(s));
+            } else if (hasTag(SelectorType.Z, s)) {
+                loc.setZ(getInt(s));
+            }
+        }
+
+        if (arg.startsWith("@s")) {
+            ents = new Entity[1];
+            if (sender instanceof Player) {
+                boolean good = true;
+                for (int b = 0; b < tags.length; b++) {
+                    if (!canBeAccepted(tags[b], (Entity) sender, loc)) {
+                        good = false;
+                        break;
                     }
                 }
+                if (good) {
+                    ents[0] = (Entity) sender;
+                }
+            } else {
+                return null;
             }
+            return ents;
+        } else if (arg.startsWith("@a")) {
+            // ents = new Entity[maxEnts];
+            List<Entity> listOfValidEntities = new ArrayList<>();
+            int C = getLimit(arg);
+
+            boolean usePlayers = true;
+            for (String tag : tags) {
+                if (hasTag(SelectorType.TYPE, tag)) {
+                    usePlayers = false;
+                    break;
+                }
+            }
+            List<Entity> ea = new ArrayList<Entity>(Bukkit.getOnlinePlayers());
+            if (!usePlayers) {
+                ea.clear();
+                for (World w : getAcceptedWorldsFullString(loc, arg)) {
+                    ea.addAll(w.getEntities());
+                }
+            }
+            for (Entity e : ea) {
+                if (listOfValidEntities.size() >= C)
+                    break;
+                boolean isValid = true;
+                for (int b = 0; b < tags.length; b++) {
+                    if (!canBeAccepted(tags[b], e, loc)) {
+                        isValid = false;
+                        break;
+                    }
+                }
+                if (isValid) {
+                    listOfValidEntities.add(e);
+                }
+            }
+
+            ents = listOfValidEntities.toArray(new Entity[listOfValidEntities.size()]);
+
         } else if (arg.startsWith("@p")) {
             ents = new Entity[1];
-            double closestInt = -1;
+            double closestInt = Double.MAX_VALUE;
             Entity closest = null;
-            for (World w : getAcceptedWorlds(loc, arg)) {
+
+            for (World w : getAcceptedWorldsFullString(loc, arg)) {
                 for (Player e : w.getPlayers()) {
-                    if (e.getLocation().equals(loc))
+                    if (e == sender)
                         continue;
-                    if (closestInt == -1
-                            || closestInt > e.getLocation().distance(loc)) {
+                    Location temp = loc;
+                    if (temp == null)
+                        temp = e.getWorld().getSpawnLocation();
+                    double distance = e.getLocation().distanceSquared(temp);
+                    if (closestInt > distance) {
                         boolean good = true;
-                        for (int b = 0; b < getTags(arg).length; b++) {
-                            if (!canBeAccepted(arg, e, loc)) {
+                        for (String tag : tags) {
+                            if (!canBeAccepted(tag, e, temp)) {
                                 good = false;
                                 break;
                             }
                         }
                         if (good) {
-                            closestInt = e.getLocation().distance(loc);
+                            closestInt = distance;
                             closest = e;
                         }
                     }
@@ -118,165 +172,190 @@ public class CommandUtils {
             }
             ents[0] = closest;
         } else if (arg.startsWith("@e")) {
-            ents = new Entity[1];
-            double closestInt = -1;
-            Entity closest = null;
-            for (World w : getAcceptedWorlds(loc, arg)) {
+            List<Entity> entities = new ArrayList<Entity>();
+            int C = getLimit(arg);
+            for (World w : getAcceptedWorldsFullString(loc, arg)) {
                 for (Entity e : w.getEntities()) {
-                    if (e.getLocation().equals(loc))
+                    if (entities.size() > C)
+                        break;
+                    if (e == sender)
                         continue;
-                    boolean good = true;
-                    if (closestInt == -1
-                            || closestInt > e.getLocation().distance(loc)) {
-                        for (int b = 0; b < getTags(arg).length; b++) {
-                            if (!canBeAccepted(arg, e, loc)) {
+                    boolean valid = true;
+                    for (String tag : tags) {
+                        if (!canBeAccepted(tag, e, loc)) {
+                            valid = false;
+                            break;
+                        }
+                    }
+                    if (valid) {
+                        entities.add(e);
+                    }
+                }
+            }
+            ents = entities.toArray(new Entity[entities.size()]);
+        } else if (arg.startsWith("@r")) {
+            Random r = ThreadLocalRandom.current();
+            ents = new Entity[1];
+
+            List<Entity> validEntities = new ArrayList<>();
+            for (World w : getAcceptedWorldsFullString(loc, arg)) {
+                if (hasTag(SelectorType.TYPE, arg)) {
+                    for (Entity e : w.getEntities()) {
+                        boolean good = true;
+                        for (String tag : tags) {
+                            if (!canBeAccepted(tag, e, loc)) {
                                 good = false;
                                 break;
                             }
                         }
-                        if (good) {
-                            closestInt = e.getLocation().distance(loc);
-                            closest = e;
-                        }
+                        if (good)
+                            validEntities.add(e);
                     }
-                }
-            }
-            ents[0] = closest;
-        } else if (arg.startsWith("@r")) {
-            Random r = ThreadLocalRandom.current();
-            ents = new Entity[1];
-            Entity entity = null;
-            int tries = 0;
-            while (entity == null && tries < 100) {
-                tries++;
-                if (hasType(arg)) {
-                    Entity e = loc
-                            .getWorld()
-                            .getEntities()
-                            .get(r.nextInt(loc.getWorld().getEntities().size()));
-                    boolean good = true;
-                    for (int b = 0; b < getTags(arg).length; b++) {
-                        if (!canBeAccepted(arg, e, loc)) {
-                            good = false;
-                            break;
-                        }
-                    }
-                    if (good)
-                        entity = e;
                 } else {
-                    List<Player> onl = new ArrayList<Player>(
-                            Bukkit.getOnlinePlayers());
-                    Entity e = onl.get(r.nextInt(onl.size()));
-                    boolean good = true;
-                    for (int b = 0; b < getTags(arg).length; b++) {
-                        if (!canBeAccepted(arg, e, loc)) {
-                            good = false;
-                            break;
+                    for (Entity e : Bukkit.getOnlinePlayers()) {
+                        boolean good = true;
+                        for (String tag : tags) {
+                            if (!canBeAccepted(tag, e, loc)) {
+                                good = false;
+                                break;
+                            }
                         }
+                        if (good)
+                            validEntities.add(e);
                     }
-                    if (good)
-                        entity = e;
                 }
             }
-            ents[0] = entity;
+            ents[0] = validEntities.get(r.nextInt(validEntities.size()));
         } else {
-            ents = new Entity[1];
-            ents[0] = Bukkit.getPlayer(arg);
+            ents = new Entity[]{Bukkit.getPlayer(arg)};
         }
         return ents;
     }
 
     /**
-     * Returns one entity. Use this if you know the player will not provide the
-     * '@a' tag.
+     * Returns one entity. Use this if you know the player will not provide the '@a'
+     * tag.
+     * <p>
+     * This can return a null variable if no tags are included, or if a value for a
+     * tag does not exist (I.e if the tag [type=___] contains an entity that does
+     * not exist in the specified world)
      *
-     * This can return a null variable if no tags are included, or if a value
-     * for a tag does not exist (I.e if the tag [type=___] contains an entity
-     * that does not exist in the specified world)
-     *
-     * @param sender Who
-     *            sent the command
-     * @param arg The
-     *            argument
+     * @param sender the command sender
+     * @param arg    the argument of the target
      * @return The first entity retrieved.
      */
     public static Entity getTarget(CommandSender sender, String arg) {
-        return getTargets(sender, arg)[0];
+        Entity[] e = getTargets(sender, arg);
+        if (e.length == 0)
+            return null;
+        return e[0];
     }
 
     /**
-     * Returns an integer. Use this to support "~" by providing what it will
-     * mean.
-     *
+     * Returns an integer. Use this to support "~" by providing what it will mean.
+     * <p>
      * E.g. rel="x" when ~ should be turn into the entity's X coord.
-     *
+     * <p>
      * Currently supports "x", "y" and "z".
      *
-     *
-     * @param arg The
-     *            argument
-     * @param rel What
-     *            the int should represent
-     * @param e The
-     *            entity to get the relative int from.
+     * @param arg The target
+     * @param rel relative to the X,Y, or Z
+     * @param e   The entity to check relative to.
      * @return the int
      */
     public static int getIntRelative(String arg, String rel, Entity e) {
         int relInt = 0;
-        switch (rel.toLowerCase()) {
-            case "x":
-                relInt = e.getLocation().getBlockX();
-                break;
-            case "y":
-                relInt = e.getLocation().getBlockY();
-                break;
-            case "z":
-                relInt = e.getLocation().getBlockZ();
-                break;
+        if (arg.startsWith("~")) {
+            switch (rel.toLowerCase()) {
+                case "x":
+                    relInt = e.getLocation().getBlockX();
+                    break;
+                case "y":
+                    relInt = e.getLocation().getBlockY();
+                    break;
+                case "z":
+                    relInt = e.getLocation().getBlockZ();
+                    break;
+            }
+            return mathIt(arg, relInt);
+        } else if (arg.startsWith("^")) {
+            // TODO: Fix code. The currently just acts the same as ~. This should move the
+            // entity relative to what its looking at.
+
+            switch (rel.toLowerCase()) {
+                case "x":
+                    relInt = e.getLocation().getBlockX();
+                    break;
+                case "y":
+                    relInt = e.getLocation().getBlockY();
+                    break;
+                case "z":
+                    relInt = e.getLocation().getBlockZ();
+                    break;
+            }
+            return mathIt(arg, relInt);
         }
-        return mathIt(arg, relInt);
+        return 0;
     }
 
     private static boolean canBeAccepted(String arg, Entity e, Location loc) {
-        if (isType(arg, e))
+        if (hasTag(SelectorType.X_ROTATION, arg) && isWithinYaw(arg, e))
             return true;
-        if (isR(arg, loc, e))
+        if (hasTag(SelectorType.Y_ROTATION, arg) && isWithinPitch(arg, e))
             return true;
-        if (isName(arg, e))
+        if (hasTag(SelectorType.TYPE, arg) && isType(arg, e))
             return true;
-        if (isRM(arg, loc, e))
+        if (hasTag(SelectorType.NAME, arg) && isName(arg, e))
             return true;
-        if (isH(arg, e))
+        if (hasTag(SelectorType.TEAM, arg) && isTeam(arg, e))
             return true;
-        if (isHM(arg, e))
+        if (hasTag(SelectorType.SCORE_FULL, arg) && isScore(arg, e))
             return true;
-        if (isM(arg, e))
+        if (hasTag(SelectorType.SCORE_MIN, arg) && isScoreMin(arg, e))
             return true;
-        if (isL(arg, e))
+        if (hasTag(SelectorType.SCORE_13, arg) && isScoreWithin(arg, e))
             return true;
-        if (isLM(arg, e))
+        if (hasTag(SelectorType.DISTANCE, arg) && isWithinDistance(arg, loc, e))
             return true;
-        if (isW(arg, loc, e))
+        if (hasTag(SelectorType.LEVEL, arg) && isWithinLevel(arg, e))
             return true;
-        if (isRX(arg, e))
+        if (hasTag(SelectorType.TAG, arg) && isHasTags(arg, e))
             return true;
-        if (isRXM(arg, e))
+        if (hasTag(SelectorType.RYM, arg) && isRYM(arg, e))
             return true;
-        if (isRY(arg, e))
+        if (hasTag(SelectorType.RXM, arg) && isRXM(arg, e))
             return true;
-        if (isTeam(arg, e))
+        if (hasTag(SelectorType.HM, arg) && isHM(arg, e))
             return true;
-        if (isScore(arg, e))
+        if (hasTag(SelectorType.RY, arg) && isRY(arg, e))
             return true;
-        if (isScoreMin(arg, e))
+        if (hasTag(SelectorType.RX, arg) && isRX(arg, e))
             return true;
-        if (isRYM(arg, e))
+        if (hasTag(SelectorType.RM, arg) && isRM(arg, loc, e))
+            return true;
+        if (hasTag(SelectorType.LMax, arg) && isLM(arg, e))
+            return true;
+        if (hasTag(SelectorType.L, arg) && isL(arg, e))
+            return true;
+        if (hasTag(SelectorType.m, arg) && isM(arg, e))
+            return true;
+        if (hasTag(SelectorType.H, arg) && isH(arg, e))
+            return true;
+        if (hasTag(SelectorType.World, arg) && isW(arg, loc, e))
+            return true;
+        if (hasTag(SelectorType.R, arg) && isR(arg, loc, e))
+            return true;
+        if (hasTag(SelectorType.X, arg))
+            return true;
+        if (hasTag(SelectorType.Y, arg))
+            return true;
+        if (hasTag(SelectorType.Z, arg))
             return true;
         return false;
     }
 
     private static String[] getTags(String arg) {
-        if(!arg.contains("["))
+        if (!arg.contains("["))
             return new String[0];
         String tags = arg.split("\\[")[1].split("\\]")[0];
         return tags.split(",");
@@ -288,8 +367,7 @@ public class CommandUtils {
         String arg = args.replace("~", String.valueOf(relInt));
         String intString = "";
         for (int i = 0; i < arg.length(); i++) {
-            if (arg.charAt(i) == '+' || arg.charAt(i) == '-'
-                    || arg.charAt(i) == '*' || arg.charAt(i) == '/') {
+            if (arg.charAt(i) == '+' || arg.charAt(i) == '-' || arg.charAt(i) == '*' || arg.charAt(i) == '/') {
                 try {
                     switch (mode) {
                         case 0:
@@ -305,17 +383,14 @@ public class CommandUtils {
                             total = total / Integer.parseInt(intString);
                             break;
                     }
-                    mode = (short) ((arg.charAt(i) == '+') ? 0 : ((arg
-                            .charAt(i) == '-') ? 1
-                            : ((arg.charAt(i) == '*') ? 2
-                            : ((arg.charAt(i) == '/') ? 3 : -1))));
+                    mode = (short) ((arg.charAt(i) == '+') ? 0
+                            : ((arg.charAt(i) == '-') ? 1
+                            : ((arg.charAt(i) == '*') ? 2 : ((arg.charAt(i) == '/') ? 3 : -1))));
                 } catch (Exception e) {
-                    Bukkit.getLogger()
-                            .severe("There has been an issue with a plugin using the CommandUtils class!");
+                    Bukkit.getLogger().severe("There has been an issue with a plugin using the CommandUtils class!");
                 }
 
-            } else if (args.length() == i || arg.charAt(i) == ' '
-                    || arg.charAt(i) == ',' || arg.charAt(i) == ']') {
+            } else if (args.length() == i || arg.charAt(i) == ' ' || arg.charAt(i) == ',' || arg.charAt(i) == ']') {
                 try {
                     switch (mode) {
                         case 0:
@@ -332,8 +407,7 @@ public class CommandUtils {
                             break;
                     }
                 } catch (Exception e) {
-                    Bukkit.getLogger()
-                            .severe("There has been an issue with a plugin using the CommandUtils class!");
+                    Bukkit.getLogger().severe("There has been an issue with a plugin using the CommandUtils class!");
                 }
                 break;
             } else {
@@ -343,150 +417,98 @@ public class CommandUtils {
         return total;
     }
 
+    private static int getLimit(String arg) {
+        if (hasTag(SelectorType.LIMIT, arg))
+            for (String s : getTags(arg)) {
+                if (hasTag(SelectorType.LIMIT, s)) {
+                    return getInt(s);
+                }
+            }
+        if (hasTag(SelectorType.C, arg))
+            for (String s : getTags(arg)) {
+                if (hasTag(SelectorType.C, s)) {
+                    return getInt(s);
+                }
+            }
+        return Integer.MAX_VALUE;
+    }
+
     private static String getType(String arg) {
-        if (hasType(arg))
+        if (hasTag(SelectorType.TYPE, arg))
             return arg.toLowerCase().split("=")[1].replace("!", "");
         return "Player";
     }
 
-    private static int getC(String arg) {
-        if (!hasC(arg))
-            return Integer.MAX_VALUE;
-        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
-    }
-
-    private static int getR(String arg) {
-        if (!hasR(arg))
-            return Integer.MAX_VALUE;
-        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
-    }
-
-    private static int getRM(String arg) {
-        if (!hasRM(arg))
-            return 1;
-        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
-    }
-
-    private static int getRX(String arg) {
-        if (!hasRX(arg))
-            return -Integer.MAX_VALUE;
-        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
-    }
-
-    private static int getRXM(String arg) {
-        if (!hasRXM(arg))
-            return -8;
-        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
-    }
-
-    private static int getRY(String arg) {
-        if (!hasRY(arg))
-            return -Integer.MAX_VALUE;
-        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
-    }
-
-    private static int getRYM(String arg) {
-        if (!hasRYM(arg))
-            return -8;
-        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
-    }
-
-    private static int getH(String arg) {
-        if (!hasH(arg))
-            return -1;
-        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
-    }
-
-    private static int getHM(String arg) {
-        if (!hasHM(arg))
-            return Integer.MAX_VALUE;
-        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
-    }
-
-    private static int getL(String arg) {
-        if (!hasL(arg))
-            return -1;
-        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
-    }
-
-    private static int getLM(String arg) {
-        if (!hasLM(arg))
-            return Integer.MAX_VALUE;
-        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
-    }
-
     private static String getName(String arg) {
         String reparg = arg.replace(" ", "_");
-        if (!hasName(reparg))
-            return null;
         return reparg.replace("!", "").split("=")[1];
     }
 
     private static World getW(String arg) {
-        if (!hasW(arg))
-            return null;
-        return Bukkit.getWorld(arg.replace("!", "").split("=")[1]);
+        return Bukkit.getWorld(getString(arg));
     }
 
     private static String getScoreMinName(String arg) {
-        if (!hasScoreMin(arg))
-            return null;
-        return arg.split("=")[0].substring(0,
-                arg.split("=")[0].length() - 1 - 4).replace("score_", "");
+        return arg.split("=")[0].substring(0, arg.split("=")[0].length() - 1 - 4).replace("score_", "");
     }
 
     private static String getScoreName(String arg) {
-        if (!hasScore(arg))
-            return null;
         return arg.split("=")[0].replace("score_", "");
     }
 
     private static String getTeam(String arg) {
-        if (!hasTeam(arg))
-            return null;
         return arg.toLowerCase().replace("!", "").split("=")[1];
     }
 
-    private static int getScoreMin(String arg) {
-        if (!hasScoreMin(arg))
-            return -8;
-        return Integer.parseInt(arg.replace("!", "").split("=")[1]);
+    private static float getValueAsFloat(String arg) {
+        return Float.parseFloat(arg.replace("!", "").split("=")[1]);
     }
 
-    private static int getScore(String arg) {
-        if (!hasScore(arg))
-            return Integer.MAX_VALUE;
+    private static int getValueAsInteger(String arg) {
         return Integer.parseInt(arg.replace("!", "").split("=")[1]);
     }
 
     private static GameMode getM(String arg) {
-        if (!hasM(arg))
-            return null;
         String[] split = arg.replace("!", "").toLowerCase().split("=");
         String returnType = split[1];
-        if (returnType.equalsIgnoreCase("0")
-                || returnType.equalsIgnoreCase("s")
+        if (returnType.equalsIgnoreCase("0") || returnType.equalsIgnoreCase("s")
                 || returnType.equalsIgnoreCase("survival"))
             return GameMode.SURVIVAL;
-        if (returnType.equalsIgnoreCase("1")
-                || returnType.equalsIgnoreCase("c")
+        if (returnType.equalsIgnoreCase("1") || returnType.equalsIgnoreCase("c")
                 || returnType.equalsIgnoreCase("creative"))
             return GameMode.CREATIVE;
-        if (returnType.equalsIgnoreCase("2")
-                || returnType.equalsIgnoreCase("a")
+        if (returnType.equalsIgnoreCase("2") || returnType.equalsIgnoreCase("a")
                 || returnType.equalsIgnoreCase("adventure"))
             return GameMode.ADVENTURE;
-        if (returnType.equalsIgnoreCase("3")
-                || returnType.equalsIgnoreCase("sp")
+        if (returnType.equalsIgnoreCase("3") || returnType.equalsIgnoreCase("sp")
                 || returnType.equalsIgnoreCase("spectator"))
             return GameMode.SPECTATOR;
         return null;
     }
 
-    private static List<World> getAcceptedWorlds(Location loc, String string) {
+    private static List<World> getAcceptedWorldsFullString(Location loc, String fullString) {
+        String string = null;
+        for (String tag : getTags(fullString)) {
+            if (hasTag(SelectorType.World, tag)) {
+                string = tag;
+                break;
+            }
+        }
+        if (string == null) {
+            List<World> worlds = new ArrayList<World>();
+            if (loc == null || loc.getWorld() == null) {
+                worlds.addAll(Bukkit.getWorlds());
+            } else {
+                worlds.add(loc.getWorld());
+            }
+            return worlds;
+        }
+        return getAcceptedWorlds(string);
+    }
+
+    private static List<World> getAcceptedWorlds(String string) {
         List<World> worlds = new ArrayList<World>(Bukkit.getWorlds());
-        if (getW(string) == null) {
-        } else if (isInverted(string)) {
+        if (isInverted(string)) {
             worlds.remove(getW(string));
         } else {
             worlds.clear();
@@ -496,12 +518,9 @@ public class CommandUtils {
     }
 
     private static boolean isTeam(String arg, Entity e) {
-        if (!hasTeam(arg))
-            return true;
         if (!(e instanceof Player))
             return false;
-        for (Team t : Bukkit.getScoreboardManager().getMainScoreboard()
-                .getTeams()) {
+        for (Team t : Bukkit.getScoreboardManager().getMainScoreboard().getTeams()) {
             if ((t.getName().equalsIgnoreCase(getTeam(arg)) != isInverted(arg))) {
                 if ((t.getEntries().contains(((Player) e).getName()) != isInverted(arg)))
                     return true;
@@ -510,30 +529,104 @@ public class CommandUtils {
         return false;
     }
 
-    private static boolean isScore(String arg, Entity e) {
-        if (!hasScore(arg))
-            return true;
+    private static boolean isWithinPitch(String arg, Entity e) {
+        float pitch = getValueAsFloat(arg);
+        return isWithinDoubleValue(isInverted(arg), arg, e.getLocation().getPitch());
+    }
+
+    private static boolean isWithinYaw(String arg, Entity e) {
+        float pitch = getValueAsFloat(arg);
+        return isWithinDoubleValue(isInverted(arg), arg, e.getLocation().getYaw());
+    }
+
+    private static boolean isWithinDistance(String arg, Location start, Entity e) {
+        double distanceMin = 0;
+        double distanceMax = Double.MAX_VALUE;
+        String distance = arg.split("=")[1];
+        if (e.getLocation().getWorld() != start.getWorld())
+            return false;
+        if (distance.contains("..")) {
+            String[] temp = distance.split("\\.\\.");
+            if (!temp[0].isEmpty()) {
+                distanceMin = Integer.parseInt(temp[0]);
+            }
+            if (temp.length > 1 && !temp[1].isEmpty()) {
+                distanceMax = Double.parseDouble(temp[1]);
+            }
+            double actDis = start.distanceSquared(e.getLocation());
+            return actDis <= distanceMax * distanceMax && distanceMin * distanceMin <= actDis;
+        } else {
+            int mult = Integer.parseInt(distance);
+            mult *= mult;
+            return ((int) start.distanceSquared(e.getLocation())) == mult;
+        }
+    }
+
+    private static boolean isWithinLevel(String arg, Entity e) {
         if (!(e instanceof Player))
             return false;
-        for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard()
-                .getObjectives()) {
+        double distanceMin = 0;
+        double distanceMax = Double.MAX_VALUE;
+        String distance = arg.split("=")[1];
+        if (distance.contains("..")) {
+            String[] temp = distance.split("..");
+            if (!temp[0].isEmpty()) {
+                distanceMin = Integer.parseInt(temp[0]);
+            }
+            if (temp[1] != null && !temp[1].isEmpty()) {
+                distanceMax = Double.parseDouble(temp[1]);
+            }
+            double actDis = ((Player) e).getExpToLevel();
+            return actDis <= distanceMax * distanceMax && distanceMin * distanceMin <= actDis;
+        } else {
+            return ((Player) e).getExpToLevel() == Integer.parseInt(distance);
+        }
+    }
+
+    private static boolean isScore(String arg, Entity e) {
+        if (!(e instanceof Player))
+            return false;
+        for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard().getObjectives()) {
             if (o.getName().equalsIgnoreCase(getScoreName(arg))) {
-                if ((o.getScore(((Player) e).getName()).getScore() <= getScore(arg) != isInverted(arg)))
+                if ((o.getScore(((Player) e).getName()).getScore() <= getValueAsInteger(arg) != isInverted(arg)))
                     return true;
             }
         }
         return false;
     }
 
-    private static boolean isScoreMin(String arg, Entity e) {
-        if (!hasScoreMin(arg))
-            return true;
+    private static boolean isScoreWithin(String arg, Entity e) {
         if (!(e instanceof Player))
             return false;
-        for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard()
-                .getObjectives()) {
+        String[] scores = arg.split("\\{")[1].split("\\}")[0].split(",");
+        for (int i = 0; i < scores.length; i++) {
+            String[] s = scores[i].split("=");
+            String name = s[0];
+
+            for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard().getObjectives()) {
+                if (o.getName().equalsIgnoreCase(name)) {
+                    if (!isWithinDoubleValue(isInverted(arg), s[1], o.getScore(e.getName()).getScore()))
+                        return false;
+                }
+            }
+        }
+        return true;
+
+    }
+
+    private static boolean isHasTags(String arg, Entity e) {
+        if (!(e instanceof Player))
+            return false;
+        return isInverted(arg) != e.getScoreboardTags().contains(getString(arg));
+
+    }
+
+    private static boolean isScoreMin(String arg, Entity e) {
+        if (!(e instanceof Player))
+            return false;
+        for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard().getObjectives()) {
             if (o.getName().equalsIgnoreCase(getScoreMinName(arg))) {
-                if ((o.getScore(((Player) e).getName()).getScore() >= getScoreMin(arg) != isInverted(arg)))
+                if ((o.getScore(((Player) e).getName()).getScore() >= getValueAsInteger(arg) != isInverted(arg)))
                     return true;
             }
         }
@@ -541,86 +634,57 @@ public class CommandUtils {
     }
 
     private static boolean isRM(String arg, Location loc, Entity e) {
-        if (!hasRM(arg))
-            return true;
-        if (isInverted(arg) != (getRM(arg) < loc.distance(e.getLocation())))
-            return true;
-        return false;
+        if (loc.getWorld() != e.getWorld())
+            return false;
+        return isGreaterThan(arg, loc.distance(e.getLocation()));
     }
 
     private static boolean isR(String arg, Location loc, Entity e) {
-        if (!hasR(arg))
-            return true;
-        if (isInverted(arg) != (getR(arg) > loc.distance(e.getLocation())))
-            return true;
-        return false;
+        if (loc.getWorld() != e.getWorld())
+            return false;
+        return isLessThan(arg, loc.distance(e.getLocation()));
 
     }
 
     private static boolean isRXM(String arg, Entity e) {
-        if (isInverted(arg) != (getRXM(arg) < e.getLocation().getYaw()))
-            return true;
-        return false;
+        return isLessThan(arg, e.getLocation().getYaw());
     }
 
     private static boolean isRX(String arg, Entity e) {
-        if (isInverted(arg) != (getRX(arg) > e.getLocation().getYaw()))
-            return true;
-        return false;
+        return isGreaterThan(arg, e.getLocation().getYaw());
     }
 
     private static boolean isRYM(String arg, Entity e) {
-        if (isInverted(arg) != (getRYM(arg) < e.getLocation().getPitch()))
-            return true;
-        return false;
+        return isLessThan(arg, e.getLocation().getPitch());
     }
 
     private static boolean isRY(String arg, Entity e) {
-        if (isInverted(arg) != (getRY(arg) > e.getLocation().getPitch()))
-            return true;
-        return false;
+        return isGreaterThan(arg, e.getLocation().getPitch());
     }
 
     private static boolean isL(String arg, Entity e) {
-        if (!hasL(arg))
-            return true;
         if (e instanceof Player) {
-            if (isInverted(arg) != (getL(arg) < ((Player) e)
-                    .getTotalExperience()))
-                return true;
+            isLessThan(arg, ((Player) e).getTotalExperience());
         }
         return false;
     }
 
     private static boolean isLM(String arg, Entity e) {
-        if (!hasLM(arg))
-            return true;
         if (e instanceof Player) {
-            if (isInverted(arg) != (getLM(arg) > ((Player) e)
-                    .getTotalExperience()))
-                return true;
-
+            return isGreaterThan(arg, ((Player) e).getTotalExperience());
         }
         return false;
     }
 
     private static boolean isH(String arg, Entity e) {
-        if (!hasH(arg))
-            return true;
-        if (e instanceof Damageable) {
-            if (isInverted(arg) != (getH(arg) > ((Damageable) e).getHealth()))
-                return true;
-        }
+        if (e instanceof Damageable)
+            return isGreaterThan(arg, ((Damageable) e).getHealth());
         return false;
     }
 
     private static boolean isHM(String arg, Entity e) {
-        if (!hasHM(arg))
-            return true;
-        if (e instanceof Damageable) {
-            if (isInverted(arg) != (getHM(arg) < ((Damageable) e).getHealth()))
-                return true;
-        }
+        if (e instanceof Damageable)
+            return isLessThan(arg, ((Damageable) e).getHealth());
         return false;
     }
 
@@ -628,8 +692,7 @@ public class CommandUtils {
         if (getM(arg) == null)
             return true;
         if (e instanceof HumanEntity) {
-            if ((isInverted(arg) != (getM(arg) == ((HumanEntity) e)
-                    .getGameMode())))
+            if ((isInverted(arg) != (getM(arg) == ((HumanEntity) e).getGameMode())))
                 return true;
         }
         return false;
@@ -638,8 +701,7 @@ public class CommandUtils {
     private static boolean isW(String arg, Location loc, Entity e) {
         if (getW(arg) == null) {
             return true;
-        } else if ((isInverted(arg) != getAcceptedWorlds(loc, arg).contains(
-                getW(arg))))
+        } else if ((isInverted(arg) != getAcceptedWorlds(arg).contains(getW(arg))))
             return true;
         return false;
     }
@@ -647,16 +709,14 @@ public class CommandUtils {
     private static boolean isName(String arg, Entity e) {
         if (getName(arg) == null)
             return true;
-        if ((isInverted(arg) != (e.getCustomName() != null) && isInverted(arg) != (getName(
-                arg).equals(e.getCustomName().replace(" ", "_")) || (e instanceof Player && ((Player) e)
-                .getName().replace(" ", "_").equalsIgnoreCase(getName(arg))))))
+        if ((isInverted(arg) != (e.getCustomName() != null) && isInverted(arg) != (getName(arg)
+                .equals(e.getCustomName().replace(" ", "_"))
+                || (e instanceof Player && ((Player) e).getName().replace(" ", "_").equalsIgnoreCase(getName(arg))))))
             return true;
         return false;
     }
 
     private static boolean isType(String arg, Entity e) {
-        if (!hasType(arg))
-            return true;
         boolean invert = isInverted(arg);
         String type = getType(arg);
         if (invert != e.getType().name().equalsIgnoreCase(type))
@@ -669,87 +729,62 @@ public class CommandUtils {
         return arg.toLowerCase().split("!").length != 1;
     }
 
-    private static boolean hasR(String arg) {
-        return arg.toLowerCase().startsWith("r=");
+    private static int getInt(String arg) {
+        int mult = Integer.parseInt(arg.split("=")[1]);
+        return mult;
     }
 
-    private static boolean hasScoreMin(String arg) {
-        boolean startW = arg.startsWith("score_");
-        if (!startW)
-            return false;
-        String[] split = arg.split("=");
-        if (split[0].endsWith("_min"))
-            return true;
-        return false;
+    public static String getString(String arg) {
+        return arg.split("=")[1].replaceAll("!", "");
     }
 
-    private static boolean hasScore(String arg) {
-        boolean startW = arg.startsWith("score_");
-        if (!startW)
-            return false;
-        String[] split = arg.split("=");
-        if (!split[0].endsWith("_min"))
-            return true;
-        return false;
+    private static boolean isLessThan(String arg, double value) {
+        boolean inverted = isInverted(arg);
+        double mult = Double.parseDouble(arg.split("=")[1]);
+        return (value < mult) != inverted;
     }
 
-    private static boolean hasRX(String arg) {
-        return arg.toLowerCase().startsWith("rx=");
+    private static boolean isGreaterThan(String arg, double value) {
+        boolean inverted = isInverted(arg);
+        double mult = Double.parseDouble(arg.split("=")[1]);
+        return (value > mult) != inverted;
     }
 
-    private static boolean hasRXM(String arg) {
-        return arg.toLowerCase().startsWith("rxm=");
+    private static boolean isWithinDoubleValue(boolean inverted, String arg, double value) {
+        double min = -Double.MAX_VALUE;
+        double max = Double.MAX_VALUE;
+        if (arg.contains("..")) {
+            String[] temp = arg.split("\\.\\.");
+            if (!temp[0].isEmpty()) {
+                min = Integer.parseInt(temp[0]);
+            }
+            if (temp.length > 1 && !temp[1].isEmpty()) {
+                max = Double.parseDouble(temp[1]);
+            }
+            return (value <= max * max && min * min <= value) != inverted;
+        } else {
+            double mult = Double.parseDouble(arg);
+            return (value == mult) != inverted;
+        }
     }
 
-    private static boolean hasRY(String arg) {
-        return arg.toLowerCase().startsWith("ry=");
+    private static boolean hasTag(SelectorType type, String arg) {
+        return arg.toLowerCase().startsWith(type.getName());
     }
 
-    private static boolean hasRYM(String arg) {
-        return arg.toLowerCase().startsWith("rym=");
-    }
+    enum SelectorType {
+        LEVEL("level="), DISTANCE("distance="), TYPE("type="), NAME("name="), TEAM("team="), LMax("lm="), L(
+                "l="), World("w="), m("m="), C("c="), HM("hm="), H("h="), RM("rm="), RYM("rym="), RX("rx="), SCORE_FULL(
+                "score="), SCORE_MIN("score_min"), SCORE_13(
+                "scores="), R("r="), RXM("rxm="), RY("ry="), TAG("tag="), X("x="), Y("y="), Z("z="), LIMIT("limit="), Y_ROTATION("y_rotation"), X_ROTATION("x_rotation");
+        String name;
 
-    private static boolean hasRM(String arg) {
-        return arg.toLowerCase().startsWith("rm=");
-    }
+        SelectorType(String s) {
+            this.name = s;
+        }
 
-    private static boolean hasH(String arg) {
-        return arg.toLowerCase().startsWith("h=");
-    }
-
-    private static boolean hasHM(String arg) {
-        return arg.toLowerCase().startsWith("hm=");
-    }
-
-    private static boolean hasC(String arg) {
-        return arg.toLowerCase().startsWith("c=");
-    }
-
-    private static boolean hasM(String arg) {
-        return arg.toLowerCase().startsWith("m=");
-    }
-
-    private static boolean hasW(String arg) {
-        return arg.toLowerCase().startsWith("w=");
-    }
-
-    private static boolean hasL(String arg) {
-        return arg.toLowerCase().startsWith("l=");
-    }
-
-    private static boolean hasLM(String arg) {
-        return arg.toLowerCase().startsWith("lm=");
-    }
-
-    private static boolean hasName(String arg) {
-        return arg.toLowerCase().startsWith("name=");
-    }
-
-    private static boolean hasTeam(String arg) {
-        return (arg.toLowerCase().startsWith("team="));
-    }
-
-    private static boolean hasType(String arg) {
-        return arg.toLowerCase().startsWith("type=");
+        public String getName() {
+            return name;
+        }
     }
 }

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/CommandUtils.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/CommandUtils.java
@@ -1,0 +1,755 @@
+package com.hm.achievement.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.command.BlockCommandSender;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Damageable;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.minecart.CommandMinecart;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Team;
+
+public class CommandUtils {
+
+    /**
+     * Use this if you are unsure if a player provided the "@a" tag. This will
+     * allow multiple entities to be retrieved.
+     *
+     * This can return a null variable if no tags are included, or if a value
+     * for a tag does not exist (I.e if the tag [type=___] contains an entity
+     * that does not exist in the specified world)
+     *
+     * The may also be empty or null values at the end of the array. Once a null
+     * value has been reached, you do not need to loop through any of the higher
+     * indexes
+     *
+     * Currently supports the tags:
+     *
+     * @p , @a , @e , @r
+     *
+     *    Currently supports the selectors: [type=] [r=] [rm=] [c=] [w=] [m=]
+     *    [name=] [l=] [lm=] [h=] [hm=] [rx=] [rxm=] [ry=] [rym=] [team=]
+     *    [score_---=] [score_---_min=]
+     *
+     *    All selectors can be inverted.
+     *
+     * @param sender The
+     *            command sender
+     * @param arg The
+     *            argument to test for
+     * @return The entities that match the criteria
+     */
+    public static Entity[] getTargets(CommandSender sender, String arg) {
+        Entity[] ents = null;
+        Location loc = null;
+        if (sender instanceof Player) {
+            loc = ((Player) sender).getLocation();
+        } else if (sender instanceof BlockCommandSender) {
+            loc = ((BlockCommandSender) sender).getBlock().getLocation();
+        } else if (sender instanceof CommandMinecart) {
+            loc = ((CommandMinecart) sender).getLocation();
+        }
+        if (arg.startsWith("@a")) {
+            if (loc != null) {
+                int maxEnts = 0;
+                for (World w : getAcceptedWorlds(loc, arg))
+                    maxEnts += w.getEntities().size();
+                ents = new Entity[maxEnts];
+                int id = 0;
+                int C = getC(arg);
+                World world3 = null;
+
+                for (World w : getAcceptedWorlds(loc, arg)) {
+                    List<Entity> ea = w.getEntities();
+                    for (int i = 0; i < w.getEntities().size(); i++) {
+                        if (world3 == null || !world3.equals(w)) {
+                            world3 = w;
+                        }
+                        if (id >= C)
+                            break;
+                        Entity e = ea.get(i);
+                        boolean good = true;
+                        for (int b = 0; b < getTags(arg).length; b++) {
+                            if (!canBeAccepted(getTags(arg)[b], e, loc)) {
+                                good = false;
+                                break;
+                            }
+                        }
+                        if (good) {
+                            ents[id] = e;
+                            id++;
+                        }
+                    }
+                }
+            }
+        } else if (arg.startsWith("@p")) {
+            ents = new Entity[1];
+            double closestInt = -1;
+            Entity closest = null;
+            for (World w : getAcceptedWorlds(loc, arg)) {
+                for (Player e : w.getPlayers()) {
+                    if (e.getLocation().equals(loc))
+                        continue;
+                    if (closestInt == -1
+                            || closestInt > e.getLocation().distance(loc)) {
+                        boolean good = true;
+                        for (int b = 0; b < getTags(arg).length; b++) {
+                            if (!canBeAccepted(arg, e, loc)) {
+                                good = false;
+                                break;
+                            }
+                        }
+                        if (good) {
+                            closestInt = e.getLocation().distance(loc);
+                            closest = e;
+                        }
+                    }
+                }
+            }
+            ents[0] = closest;
+        } else if (arg.startsWith("@e")) {
+            ents = new Entity[1];
+            double closestInt = -1;
+            Entity closest = null;
+            for (World w : getAcceptedWorlds(loc, arg)) {
+                for (Entity e : w.getEntities()) {
+                    if (e.getLocation().equals(loc))
+                        continue;
+                    boolean good = true;
+                    if (closestInt == -1
+                            || closestInt > e.getLocation().distance(loc)) {
+                        for (int b = 0; b < getTags(arg).length; b++) {
+                            if (!canBeAccepted(arg, e, loc)) {
+                                good = false;
+                                break;
+                            }
+                        }
+                        if (good) {
+                            closestInt = e.getLocation().distance(loc);
+                            closest = e;
+                        }
+                    }
+                }
+            }
+            ents[0] = closest;
+        } else if (arg.startsWith("@r")) {
+            Random r = ThreadLocalRandom.current();
+            ents = new Entity[1];
+            Entity entity = null;
+            int tries = 0;
+            while (entity == null && tries < 100) {
+                tries++;
+                if (hasType(arg)) {
+                    Entity e = loc
+                            .getWorld()
+                            .getEntities()
+                            .get(r.nextInt(loc.getWorld().getEntities().size()));
+                    boolean good = true;
+                    for (int b = 0; b < getTags(arg).length; b++) {
+                        if (!canBeAccepted(arg, e, loc)) {
+                            good = false;
+                            break;
+                        }
+                    }
+                    if (good)
+                        entity = e;
+                } else {
+                    List<Player> onl = new ArrayList<Player>(
+                            Bukkit.getOnlinePlayers());
+                    Entity e = onl.get(r.nextInt(onl.size()));
+                    boolean good = true;
+                    for (int b = 0; b < getTags(arg).length; b++) {
+                        if (!canBeAccepted(arg, e, loc)) {
+                            good = false;
+                            break;
+                        }
+                    }
+                    if (good)
+                        entity = e;
+                }
+            }
+            ents[0] = entity;
+        } else {
+            ents = new Entity[1];
+            ents[0] = Bukkit.getPlayer(arg);
+        }
+        return ents;
+    }
+
+    /**
+     * Returns one entity. Use this if you know the player will not provide the
+     * '@a' tag.
+     *
+     * This can return a null variable if no tags are included, or if a value
+     * for a tag does not exist (I.e if the tag [type=___] contains an entity
+     * that does not exist in the specified world)
+     *
+     * @param sender Who
+     *            sent the command
+     * @param arg The
+     *            argument
+     * @return The first entity retrieved.
+     */
+    public static Entity getTarget(CommandSender sender, String arg) {
+        return getTargets(sender, arg)[0];
+    }
+
+    /**
+     * Returns an integer. Use this to support "~" by providing what it will
+     * mean.
+     *
+     * E.g. rel="x" when ~ should be turn into the entity's X coord.
+     *
+     * Currently supports "x", "y" and "z".
+     *
+     *
+     * @param arg The
+     *            argument
+     * @param rel What
+     *            the int should represent
+     * @param e The
+     *            entity to get the relative int from.
+     * @return the int
+     */
+    public static int getIntRelative(String arg, String rel, Entity e) {
+        int relInt = 0;
+        switch (rel.toLowerCase()) {
+            case "x":
+                relInt = e.getLocation().getBlockX();
+                break;
+            case "y":
+                relInt = e.getLocation().getBlockY();
+                break;
+            case "z":
+                relInt = e.getLocation().getBlockZ();
+                break;
+        }
+        return mathIt(arg, relInt);
+    }
+
+    private static boolean canBeAccepted(String arg, Entity e, Location loc) {
+        if (isType(arg, e))
+            return true;
+        if (isR(arg, loc, e))
+            return true;
+        if (isName(arg, e))
+            return true;
+        if (isRM(arg, loc, e))
+            return true;
+        if (isH(arg, e))
+            return true;
+        if (isHM(arg, e))
+            return true;
+        if (isM(arg, e))
+            return true;
+        if (isL(arg, e))
+            return true;
+        if (isLM(arg, e))
+            return true;
+        if (isW(arg, loc, e))
+            return true;
+        if (isRX(arg, e))
+            return true;
+        if (isRXM(arg, e))
+            return true;
+        if (isRY(arg, e))
+            return true;
+        if (isTeam(arg, e))
+            return true;
+        if (isScore(arg, e))
+            return true;
+        if (isScoreMin(arg, e))
+            return true;
+        if (isRYM(arg, e))
+            return true;
+        return false;
+    }
+
+    private static String[] getTags(String arg) {
+        if(!arg.contains("["))
+            return new String[0];
+        String tags = arg.split("\\[")[1].split("\\]")[0];
+        return tags.split(",");
+    }
+
+    private static int mathIt(String args, int relInt) {
+        int total = 0;
+        short mode = 0;
+        String arg = args.replace("~", String.valueOf(relInt));
+        String intString = "";
+        for (int i = 0; i < arg.length(); i++) {
+            if (arg.charAt(i) == '+' || arg.charAt(i) == '-'
+                    || arg.charAt(i) == '*' || arg.charAt(i) == '/') {
+                try {
+                    switch (mode) {
+                        case 0:
+                            total = total + Integer.parseInt(intString);
+                            break;
+                        case 1:
+                            total = total - Integer.parseInt(intString);
+                            break;
+                        case 2:
+                            total = total * Integer.parseInt(intString);
+                            break;
+                        case 3:
+                            total = total / Integer.parseInt(intString);
+                            break;
+                    }
+                    mode = (short) ((arg.charAt(i) == '+') ? 0 : ((arg
+                            .charAt(i) == '-') ? 1
+                            : ((arg.charAt(i) == '*') ? 2
+                            : ((arg.charAt(i) == '/') ? 3 : -1))));
+                } catch (Exception e) {
+                    Bukkit.getLogger()
+                            .severe("There has been an issue with a plugin using the CommandUtils class!");
+                }
+
+            } else if (args.length() == i || arg.charAt(i) == ' '
+                    || arg.charAt(i) == ',' || arg.charAt(i) == ']') {
+                try {
+                    switch (mode) {
+                        case 0:
+                            total = total + Integer.parseInt(intString);
+                            break;
+                        case 1:
+                            total = total - Integer.parseInt(intString);
+                            break;
+                        case 2:
+                            total = total * Integer.parseInt(intString);
+                            break;
+                        case 3:
+                            total = total / Integer.parseInt(intString);
+                            break;
+                    }
+                } catch (Exception e) {
+                    Bukkit.getLogger()
+                            .severe("There has been an issue with a plugin using the CommandUtils class!");
+                }
+                break;
+            } else {
+                intString += arg.charAt(i);
+            }
+        }
+        return total;
+    }
+
+    private static String getType(String arg) {
+        if (hasType(arg))
+            return arg.toLowerCase().split("=")[1].replace("!", "");
+        return "Player";
+    }
+
+    private static int getC(String arg) {
+        if (!hasC(arg))
+            return Integer.MAX_VALUE;
+        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
+    }
+
+    private static int getR(String arg) {
+        if (!hasR(arg))
+            return Integer.MAX_VALUE;
+        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
+    }
+
+    private static int getRM(String arg) {
+        if (!hasRM(arg))
+            return 1;
+        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
+    }
+
+    private static int getRX(String arg) {
+        if (!hasRX(arg))
+            return -Integer.MAX_VALUE;
+        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
+    }
+
+    private static int getRXM(String arg) {
+        if (!hasRXM(arg))
+            return -8;
+        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
+    }
+
+    private static int getRY(String arg) {
+        if (!hasRY(arg))
+            return -Integer.MAX_VALUE;
+        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
+    }
+
+    private static int getRYM(String arg) {
+        if (!hasRYM(arg))
+            return -8;
+        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
+    }
+
+    private static int getH(String arg) {
+        if (!hasH(arg))
+            return -1;
+        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
+    }
+
+    private static int getHM(String arg) {
+        if (!hasHM(arg))
+            return Integer.MAX_VALUE;
+        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
+    }
+
+    private static int getL(String arg) {
+        if (!hasL(arg))
+            return -1;
+        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
+    }
+
+    private static int getLM(String arg) {
+        if (!hasLM(arg))
+            return Integer.MAX_VALUE;
+        return Integer.parseInt(arg.toLowerCase().replace("!", "").split("=")[1]);
+    }
+
+    private static String getName(String arg) {
+        String reparg = arg.replace(" ", "_");
+        if (!hasName(reparg))
+            return null;
+        return reparg.replace("!", "").split("=")[1];
+    }
+
+    private static World getW(String arg) {
+        if (!hasW(arg))
+            return null;
+        return Bukkit.getWorld(arg.replace("!", "").split("=")[1]);
+    }
+
+    private static String getScoreMinName(String arg) {
+        if (!hasScoreMin(arg))
+            return null;
+        return arg.split("=")[0].substring(0,
+                arg.split("=")[0].length() - 1 - 4).replace("score_", "");
+    }
+
+    private static String getScoreName(String arg) {
+        if (!hasScore(arg))
+            return null;
+        return arg.split("=")[0].replace("score_", "");
+    }
+
+    private static String getTeam(String arg) {
+        if (!hasTeam(arg))
+            return null;
+        return arg.toLowerCase().replace("!", "").split("=")[1];
+    }
+
+    private static int getScoreMin(String arg) {
+        if (!hasScoreMin(arg))
+            return -8;
+        return Integer.parseInt(arg.replace("!", "").split("=")[1]);
+    }
+
+    private static int getScore(String arg) {
+        if (!hasScore(arg))
+            return Integer.MAX_VALUE;
+        return Integer.parseInt(arg.replace("!", "").split("=")[1]);
+    }
+
+    private static GameMode getM(String arg) {
+        if (!hasM(arg))
+            return null;
+        String[] split = arg.replace("!", "").toLowerCase().split("=");
+        String returnType = split[1];
+        if (returnType.equalsIgnoreCase("0")
+                || returnType.equalsIgnoreCase("s")
+                || returnType.equalsIgnoreCase("survival"))
+            return GameMode.SURVIVAL;
+        if (returnType.equalsIgnoreCase("1")
+                || returnType.equalsIgnoreCase("c")
+                || returnType.equalsIgnoreCase("creative"))
+            return GameMode.CREATIVE;
+        if (returnType.equalsIgnoreCase("2")
+                || returnType.equalsIgnoreCase("a")
+                || returnType.equalsIgnoreCase("adventure"))
+            return GameMode.ADVENTURE;
+        if (returnType.equalsIgnoreCase("3")
+                || returnType.equalsIgnoreCase("sp")
+                || returnType.equalsIgnoreCase("spectator"))
+            return GameMode.SPECTATOR;
+        return null;
+    }
+
+    private static List<World> getAcceptedWorlds(Location loc, String string) {
+        List<World> worlds = new ArrayList<World>(Bukkit.getWorlds());
+        if (getW(string) == null) {
+        } else if (isInverted(string)) {
+            worlds.remove(getW(string));
+        } else {
+            worlds.clear();
+            worlds.add(getW(string));
+        }
+        return worlds;
+    }
+
+    private static boolean isTeam(String arg, Entity e) {
+        if (!hasTeam(arg))
+            return true;
+        if (!(e instanceof Player))
+            return false;
+        for (Team t : Bukkit.getScoreboardManager().getMainScoreboard()
+                .getTeams()) {
+            if ((t.getName().equalsIgnoreCase(getTeam(arg)) != isInverted(arg))) {
+                if ((t.getEntries().contains(((Player) e).getName()) != isInverted(arg)))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isScore(String arg, Entity e) {
+        if (!hasScore(arg))
+            return true;
+        if (!(e instanceof Player))
+            return false;
+        for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard()
+                .getObjectives()) {
+            if (o.getName().equalsIgnoreCase(getScoreName(arg))) {
+                if ((o.getScore(((Player) e).getName()).getScore() <= getScore(arg) != isInverted(arg)))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isScoreMin(String arg, Entity e) {
+        if (!hasScoreMin(arg))
+            return true;
+        if (!(e instanceof Player))
+            return false;
+        for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard()
+                .getObjectives()) {
+            if (o.getName().equalsIgnoreCase(getScoreMinName(arg))) {
+                if ((o.getScore(((Player) e).getName()).getScore() >= getScoreMin(arg) != isInverted(arg)))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isRM(String arg, Location loc, Entity e) {
+        if (!hasRM(arg))
+            return true;
+        if (isInverted(arg) != (getRM(arg) < loc.distance(e.getLocation())))
+            return true;
+        return false;
+    }
+
+    private static boolean isR(String arg, Location loc, Entity e) {
+        if (!hasR(arg))
+            return true;
+        if (isInverted(arg) != (getR(arg) > loc.distance(e.getLocation())))
+            return true;
+        return false;
+
+    }
+
+    private static boolean isRXM(String arg, Entity e) {
+        if (isInverted(arg) != (getRXM(arg) < e.getLocation().getYaw()))
+            return true;
+        return false;
+    }
+
+    private static boolean isRX(String arg, Entity e) {
+        if (isInverted(arg) != (getRX(arg) > e.getLocation().getYaw()))
+            return true;
+        return false;
+    }
+
+    private static boolean isRYM(String arg, Entity e) {
+        if (isInverted(arg) != (getRYM(arg) < e.getLocation().getPitch()))
+            return true;
+        return false;
+    }
+
+    private static boolean isRY(String arg, Entity e) {
+        if (isInverted(arg) != (getRY(arg) > e.getLocation().getPitch()))
+            return true;
+        return false;
+    }
+
+    private static boolean isL(String arg, Entity e) {
+        if (!hasL(arg))
+            return true;
+        if (e instanceof Player) {
+            if (isInverted(arg) != (getL(arg) < ((Player) e)
+                    .getTotalExperience()))
+                return true;
+        }
+        return false;
+    }
+
+    private static boolean isLM(String arg, Entity e) {
+        if (!hasLM(arg))
+            return true;
+        if (e instanceof Player) {
+            if (isInverted(arg) != (getLM(arg) > ((Player) e)
+                    .getTotalExperience()))
+                return true;
+
+        }
+        return false;
+    }
+
+    private static boolean isH(String arg, Entity e) {
+        if (!hasH(arg))
+            return true;
+        if (e instanceof Damageable) {
+            if (isInverted(arg) != (getH(arg) > ((Damageable) e).getHealth()))
+                return true;
+        }
+        return false;
+    }
+
+    private static boolean isHM(String arg, Entity e) {
+        if (!hasHM(arg))
+            return true;
+        if (e instanceof Damageable) {
+            if (isInverted(arg) != (getHM(arg) < ((Damageable) e).getHealth()))
+                return true;
+        }
+        return false;
+    }
+
+    private static boolean isM(String arg, Entity e) {
+        if (getM(arg) == null)
+            return true;
+        if (e instanceof HumanEntity) {
+            if ((isInverted(arg) != (getM(arg) == ((HumanEntity) e)
+                    .getGameMode())))
+                return true;
+        }
+        return false;
+    }
+
+    private static boolean isW(String arg, Location loc, Entity e) {
+        if (getW(arg) == null) {
+            return true;
+        } else if ((isInverted(arg) != getAcceptedWorlds(loc, arg).contains(
+                getW(arg))))
+            return true;
+        return false;
+    }
+
+    private static boolean isName(String arg, Entity e) {
+        if (getName(arg) == null)
+            return true;
+        if ((isInverted(arg) != (e.getCustomName() != null) && isInverted(arg) != (getName(
+                arg).equals(e.getCustomName().replace(" ", "_")) || (e instanceof Player && ((Player) e)
+                .getName().replace(" ", "_").equalsIgnoreCase(getName(arg))))))
+            return true;
+        return false;
+    }
+
+    private static boolean isType(String arg, Entity e) {
+        if (!hasType(arg))
+            return true;
+        boolean invert = isInverted(arg);
+        String type = getType(arg);
+        if (invert != e.getType().name().equalsIgnoreCase(type))
+            return true;
+        return false;
+
+    }
+
+    private static boolean isInverted(String arg) {
+        return arg.toLowerCase().split("!").length != 1;
+    }
+
+    private static boolean hasR(String arg) {
+        return arg.toLowerCase().startsWith("r=");
+    }
+
+    private static boolean hasScoreMin(String arg) {
+        boolean startW = arg.startsWith("score_");
+        if (!startW)
+            return false;
+        String[] split = arg.split("=");
+        if (split[0].endsWith("_min"))
+            return true;
+        return false;
+    }
+
+    private static boolean hasScore(String arg) {
+        boolean startW = arg.startsWith("score_");
+        if (!startW)
+            return false;
+        String[] split = arg.split("=");
+        if (!split[0].endsWith("_min"))
+            return true;
+        return false;
+    }
+
+    private static boolean hasRX(String arg) {
+        return arg.toLowerCase().startsWith("rx=");
+    }
+
+    private static boolean hasRXM(String arg) {
+        return arg.toLowerCase().startsWith("rxm=");
+    }
+
+    private static boolean hasRY(String arg) {
+        return arg.toLowerCase().startsWith("ry=");
+    }
+
+    private static boolean hasRYM(String arg) {
+        return arg.toLowerCase().startsWith("rym=");
+    }
+
+    private static boolean hasRM(String arg) {
+        return arg.toLowerCase().startsWith("rm=");
+    }
+
+    private static boolean hasH(String arg) {
+        return arg.toLowerCase().startsWith("h=");
+    }
+
+    private static boolean hasHM(String arg) {
+        return arg.toLowerCase().startsWith("hm=");
+    }
+
+    private static boolean hasC(String arg) {
+        return arg.toLowerCase().startsWith("c=");
+    }
+
+    private static boolean hasM(String arg) {
+        return arg.toLowerCase().startsWith("m=");
+    }
+
+    private static boolean hasW(String arg) {
+        return arg.toLowerCase().startsWith("w=");
+    }
+
+    private static boolean hasL(String arg) {
+        return arg.toLowerCase().startsWith("l=");
+    }
+
+    private static boolean hasLM(String arg) {
+        return arg.toLowerCase().startsWith("lm=");
+    }
+
+    private static boolean hasName(String arg) {
+        return arg.toLowerCase().startsWith("name=");
+    }
+
+    private static boolean hasTeam(String arg) {
+        return (arg.toLowerCase().startsWith("team="));
+    }
+
+    private static boolean hasType(String arg) {
+        return arg.toLowerCase().startsWith("type=");
+    }
+}

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/CommandUtils.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/CommandUtils.java
@@ -40,758 +40,777 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class CommandUtils {
 
-    /**
-     * The CommandUtils class is used for selector support in commands (@p, @a etc.)
-     * Originally made by ZombieStriker
-     * https://github.com/ZombieStriker/PsudoCommands/blob/master/src/me/zombie_striker/psudocommands/CommandUtils.java
-     * https://github.com/ZombieStriker/CommandUtils/blob/master/src/CommandUtils.java
-     * */
-
-    /**
-     * Use this if you are unsure if a player provided the "@a" tag. This will allow
-     * multiple entities to be retrieved.
-     * <p>
-     * This can return a null variable if no tags are included, or if a value for a
-     * tag does not exist (I.e if the tag [type=___] contains an entity that does
-     * not exist in the specified world)
-     * <p>
-     * The may also be empty or null values at the end of the array. Once a null
-     * value has been reached, you do not need to loop through any of the higher
-     * indexes
-     * <p>
-     * Currently supports the tags:
-     *
-     * @param arg    the argument that we are testing for
-     * @param sender the sender of the command
-     * @return The entities that match the criteria
-     * @p , @a , @e , @r
-     * <p>
-     * Currently supports the selectors: [type=] [r=] [rm=] [c=] [w=] [m=]
-     * [name=] [l=] [lm=] [h=] [hm=] [rx=] [rxm=] [ry=] [rym=] [team=]
-     * [score_---=] [score_---_min=] [x] [y] [z] [limit=] [x_rotation] [y_rotation]
-     * <p>
-     * All selectors can be inverted.
-     */
-    public static Entity[] getTargets(CommandSender sender, String arg) {
-        Entity[] ents;
-        Location loc = null;
-        if (sender instanceof Player) {
-            loc = ((Player) sender).getLocation();
-        } else if (sender instanceof BlockCommandSender) {
-            // Center of block.
-            loc = ((BlockCommandSender) sender).getBlock().getLocation().add(0.5, 0, 0.5);
-        } else if (sender instanceof CommandMinecart) {
-            loc = ((CommandMinecart) sender).getLocation();
-        }
-        String[] tags = getTags(arg);
-
-        // prefab fix
-        for (String s : tags) {
-            if (hasTag(SelectorType.X, s)) {
-                loc.setX(getInt(s));
-            } else if (hasTag(SelectorType.Y, s)) {
-                loc.setY(getInt(s));
-            } else if (hasTag(SelectorType.Z, s)) {
-                loc.setZ(getInt(s));
-            }
-        }
-
-        if (arg.startsWith("@s")) {
-            ents = new Entity[1];
-            if (sender instanceof Player) {
-                boolean good = true;
-                for (int b = 0; b < tags.length; b++) {
-                    if (!canBeAccepted(tags[b], (Entity) sender, loc)) {
-                        good = false;
-                        break;
-                    }
-                }
-                if (good) {
-                    ents[0] = (Entity) sender;
-                }
-            } else {
-                return null;
-            }
-            return ents;
-        } else if (arg.startsWith("@a")) {
-            // ents = new Entity[maxEnts];
-            List<Entity> listOfValidEntities = new ArrayList<>();
-            int C = getLimit(arg);
-
-            boolean usePlayers = true;
-            for (String tag : tags) {
-                if (hasTag(SelectorType.TYPE, tag)) {
-                    usePlayers = false;
-                    break;
-                }
-            }
-            List<Entity> ea = new ArrayList<Entity>(Bukkit.getOnlinePlayers());
-            if (!usePlayers) {
-                ea.clear();
-                for (World w : getAcceptedWorldsFullString(loc, arg)) {
-                    ea.addAll(w.getEntities());
-                }
-            }
-            for (Entity e : ea) {
-                if (listOfValidEntities.size() >= C)
-                    break;
-                boolean isValid = true;
-                for (int b = 0; b < tags.length; b++) {
-                    if (!canBeAccepted(tags[b], e, loc)) {
-                        isValid = false;
-                        break;
-                    }
-                }
-                if (isValid) {
-                    listOfValidEntities.add(e);
-                }
-            }
-
-            ents = listOfValidEntities.toArray(new Entity[listOfValidEntities.size()]);
-
-        } else if (arg.startsWith("@p")) {
-            ents = new Entity[1];
-            double closestInt = Double.MAX_VALUE;
-            Entity closest = null;
-
-            for (World w : getAcceptedWorldsFullString(loc, arg)) {
-                for (Player e : w.getPlayers()) {
-                    if (e == sender)
-                        continue;
-                    Location temp = loc;
-                    if (temp == null)
-                        temp = e.getWorld().getSpawnLocation();
-                    double distance = e.getLocation().distanceSquared(temp);
-                    if (closestInt > distance) {
-                        boolean good = true;
-                        for (String tag : tags) {
-                            if (!canBeAccepted(tag, e, temp)) {
-                                good = false;
-                                break;
-                            }
-                        }
-                        if (good) {
-                            closestInt = distance;
-                            closest = e;
-                        }
-                    }
-                }
-            }
-            ents[0] = closest;
-        } else if (arg.startsWith("@e")) {
-            List<Entity> entities = new ArrayList<Entity>();
-            int C = getLimit(arg);
-            for (World w : getAcceptedWorldsFullString(loc, arg)) {
-                for (Entity e : w.getEntities()) {
-                    if (entities.size() > C)
-                        break;
-                    if (e == sender)
-                        continue;
-                    boolean valid = true;
-                    for (String tag : tags) {
-                        if (!canBeAccepted(tag, e, loc)) {
-                            valid = false;
-                            break;
-                        }
-                    }
-                    if (valid) {
-                        entities.add(e);
-                    }
-                }
-            }
-            ents = entities.toArray(new Entity[entities.size()]);
-        } else if (arg.startsWith("@r")) {
-            Random r = ThreadLocalRandom.current();
-            ents = new Entity[1];
-
-            List<Entity> validEntities = new ArrayList<>();
-            for (World w : getAcceptedWorldsFullString(loc, arg)) {
-                if (hasTag(SelectorType.TYPE, arg)) {
-                    for (Entity e : w.getEntities()) {
-                        boolean good = true;
-                        for (String tag : tags) {
-                            if (!canBeAccepted(tag, e, loc)) {
-                                good = false;
-                                break;
-                            }
-                        }
-                        if (good)
-                            validEntities.add(e);
-                    }
-                } else {
-                    for (Entity e : Bukkit.getOnlinePlayers()) {
-                        boolean good = true;
-                        for (String tag : tags) {
-                            if (!canBeAccepted(tag, e, loc)) {
-                                good = false;
-                                break;
-                            }
-                        }
-                        if (good)
-                            validEntities.add(e);
-                    }
-                }
-            }
-            ents[0] = validEntities.get(r.nextInt(validEntities.size()));
-        } else {
-            ents = new Entity[]{Bukkit.getPlayer(arg)};
-        }
-        return ents;
-    }
-
-    /**
-     * Returns one entity. Use this if you know the player will not provide the '@a'
-     * tag.
-     * <p>
-     * This can return a null variable if no tags are included, or if a value for a
-     * tag does not exist (I.e if the tag [type=___] contains an entity that does
-     * not exist in the specified world)
-     *
-     * @param sender the command sender
-     * @param arg    the argument of the target
-     * @return The first entity retrieved.
-     */
-    public static Entity getTarget(CommandSender sender, String arg) {
-        Entity[] e = getTargets(sender, arg);
-        if (e.length == 0)
-            return null;
-        return e[0];
-    }
-
-    /**
-     * Returns an integer. Use this to support "~" by providing what it will mean.
-     * <p>
-     * E.g. rel="x" when ~ should be turn into the entity's X coord.
-     * <p>
-     * Currently supports "x", "y" and "z".
-     *
-     * @param arg The target
-     * @param rel relative to the X,Y, or Z
-     * @param e   The entity to check relative to.
-     * @return the int
-     */
-    public static int getIntRelative(String arg, String rel, Entity e) {
-        int relInt = 0;
-        if (arg.startsWith("~")) {
-            switch (rel.toLowerCase()) {
-                case "x":
-                    relInt = e.getLocation().getBlockX();
-                    break;
-                case "y":
-                    relInt = e.getLocation().getBlockY();
-                    break;
-                case "z":
-                    relInt = e.getLocation().getBlockZ();
-                    break;
-            }
-            return mathIt(arg, relInt);
-        } else if (arg.startsWith("^")) {
-            // TODO: Fix code. The currently just acts the same as ~. This should move the
-            // entity relative to what its looking at.
-
-            switch (rel.toLowerCase()) {
-                case "x":
-                    relInt = e.getLocation().getBlockX();
-                    break;
-                case "y":
-                    relInt = e.getLocation().getBlockY();
-                    break;
-                case "z":
-                    relInt = e.getLocation().getBlockZ();
-                    break;
-            }
-            return mathIt(arg, relInt);
-        }
-        return 0;
-    }
-
-    private static boolean canBeAccepted(String arg, Entity e, Location loc) {
-        if (hasTag(SelectorType.X_ROTATION, arg) && isWithinYaw(arg, e))
-            return true;
-        if (hasTag(SelectorType.Y_ROTATION, arg) && isWithinPitch(arg, e))
-            return true;
-        if (hasTag(SelectorType.TYPE, arg) && isType(arg, e))
-            return true;
-        if (hasTag(SelectorType.NAME, arg) && isName(arg, e))
-            return true;
-        if (hasTag(SelectorType.TEAM, arg) && isTeam(arg, e))
-            return true;
-        if (hasTag(SelectorType.SCORE_FULL, arg) && isScore(arg, e))
-            return true;
-        if (hasTag(SelectorType.SCORE_MIN, arg) && isScoreMin(arg, e))
-            return true;
-        if (hasTag(SelectorType.SCORE_13, arg) && isScoreWithin(arg, e))
-            return true;
-        if (hasTag(SelectorType.DISTANCE, arg) && isWithinDistance(arg, loc, e))
-            return true;
-        if (hasTag(SelectorType.LEVEL, arg) && isWithinLevel(arg, e))
-            return true;
-        if (hasTag(SelectorType.TAG, arg) && isHasTags(arg, e))
-            return true;
-        if (hasTag(SelectorType.RYM, arg) && isRYM(arg, e))
-            return true;
-        if (hasTag(SelectorType.RXM, arg) && isRXM(arg, e))
-            return true;
-        if (hasTag(SelectorType.HM, arg) && isHM(arg, e))
-            return true;
-        if (hasTag(SelectorType.RY, arg) && isRY(arg, e))
-            return true;
-        if (hasTag(SelectorType.RX, arg) && isRX(arg, e))
-            return true;
-        if (hasTag(SelectorType.RM, arg) && isRM(arg, loc, e))
-            return true;
-        if (hasTag(SelectorType.LMax, arg) && isLM(arg, e))
-            return true;
-        if (hasTag(SelectorType.L, arg) && isL(arg, e))
-            return true;
-        if (hasTag(SelectorType.m, arg) && isM(arg, e))
-            return true;
-        if (hasTag(SelectorType.H, arg) && isH(arg, e))
-            return true;
-        if (hasTag(SelectorType.World, arg) && isW(arg, loc, e))
-            return true;
-        if (hasTag(SelectorType.R, arg) && isR(arg, loc, e))
-            return true;
-        if (hasTag(SelectorType.X, arg))
-            return true;
-        if (hasTag(SelectorType.Y, arg))
-            return true;
-        if (hasTag(SelectorType.Z, arg))
-            return true;
-        return false;
-    }
-
-    private static String[] getTags(String arg) {
-        if (!arg.contains("["))
-            return new String[0];
-        String tags = arg.split("\\[")[1].split("\\]")[0];
-        return tags.split(",");
-    }
-
-    private static int mathIt(String args, int relInt) {
-        int total = 0;
-        short mode = 0;
-        String arg = args.replace("~", String.valueOf(relInt));
-        String intString = "";
-        for (int i = 0; i < arg.length(); i++) {
-            if (arg.charAt(i) == '+' || arg.charAt(i) == '-' || arg.charAt(i) == '*' || arg.charAt(i) == '/') {
-                try {
-                    switch (mode) {
-                        case 0:
-                            total = total + Integer.parseInt(intString);
-                            break;
-                        case 1:
-                            total = total - Integer.parseInt(intString);
-                            break;
-                        case 2:
-                            total = total * Integer.parseInt(intString);
-                            break;
-                        case 3:
-                            total = total / Integer.parseInt(intString);
-                            break;
-                    }
-                    mode = (short) ((arg.charAt(i) == '+') ? 0
-                            : ((arg.charAt(i) == '-') ? 1
-                            : ((arg.charAt(i) == '*') ? 2 : ((arg.charAt(i) == '/') ? 3 : -1))));
-                } catch (Exception e) {
-                    Bukkit.getLogger().severe("There has been an issue with a plugin using the CommandUtils class!");
-                }
-
-            } else if (args.length() == i || arg.charAt(i) == ' ' || arg.charAt(i) == ',' || arg.charAt(i) == ']') {
-                try {
-                    switch (mode) {
-                        case 0:
-                            total = total + Integer.parseInt(intString);
-                            break;
-                        case 1:
-                            total = total - Integer.parseInt(intString);
-                            break;
-                        case 2:
-                            total = total * Integer.parseInt(intString);
-                            break;
-                        case 3:
-                            total = total / Integer.parseInt(intString);
-                            break;
-                    }
-                } catch (Exception e) {
-                    Bukkit.getLogger().severe("There has been an issue with a plugin using the CommandUtils class!");
-                }
-                break;
-            } else {
-                intString += arg.charAt(i);
-            }
-        }
-        return total;
-    }
-
-    private static int getLimit(String arg) {
-        if (hasTag(SelectorType.LIMIT, arg))
-            for (String s : getTags(arg)) {
-                if (hasTag(SelectorType.LIMIT, s)) {
-                    return getInt(s);
-                }
-            }
-        if (hasTag(SelectorType.C, arg))
-            for (String s : getTags(arg)) {
-                if (hasTag(SelectorType.C, s)) {
-                    return getInt(s);
-                }
-            }
-        return Integer.MAX_VALUE;
-    }
-
-    private static String getType(String arg) {
-        if (hasTag(SelectorType.TYPE, arg))
-            return arg.toLowerCase().split("=")[1].replace("!", "");
-        return "Player";
-    }
-
-    private static String getName(String arg) {
-        String reparg = arg.replace(" ", "_");
-        return reparg.replace("!", "").split("=")[1];
-    }
-
-    private static World getW(String arg) {
-        return Bukkit.getWorld(getString(arg));
-    }
-
-    private static String getScoreMinName(String arg) {
-        return arg.split("=")[0].substring(0, arg.split("=")[0].length() - 1 - 4).replace("score_", "");
-    }
-
-    private static String getScoreName(String arg) {
-        return arg.split("=")[0].replace("score_", "");
-    }
-
-    private static String getTeam(String arg) {
-        return arg.toLowerCase().replace("!", "").split("=")[1];
-    }
-
-    private static float getValueAsFloat(String arg) {
-        return Float.parseFloat(arg.replace("!", "").split("=")[1]);
-    }
-
-    private static int getValueAsInteger(String arg) {
-        return Integer.parseInt(arg.replace("!", "").split("=")[1]);
-    }
-
-    private static GameMode getM(String arg) {
-        String[] split = arg.replace("!", "").toLowerCase().split("=");
-        String returnType = split[1];
-        if (returnType.equalsIgnoreCase("0") || returnType.equalsIgnoreCase("s")
-                || returnType.equalsIgnoreCase("survival"))
-            return GameMode.SURVIVAL;
-        if (returnType.equalsIgnoreCase("1") || returnType.equalsIgnoreCase("c")
-                || returnType.equalsIgnoreCase("creative"))
-            return GameMode.CREATIVE;
-        if (returnType.equalsIgnoreCase("2") || returnType.equalsIgnoreCase("a")
-                || returnType.equalsIgnoreCase("adventure"))
-            return GameMode.ADVENTURE;
-        if (returnType.equalsIgnoreCase("3") || returnType.equalsIgnoreCase("sp")
-                || returnType.equalsIgnoreCase("spectator"))
-            return GameMode.SPECTATOR;
-        return null;
-    }
-
-    private static List<World> getAcceptedWorldsFullString(Location loc, String fullString) {
-        String string = null;
-        for (String tag : getTags(fullString)) {
-            if (hasTag(SelectorType.World, tag)) {
-                string = tag;
-                break;
-            }
-        }
-        if (string == null) {
-            List<World> worlds = new ArrayList<World>();
-            if (loc == null || loc.getWorld() == null) {
-                worlds.addAll(Bukkit.getWorlds());
-            } else {
-                worlds.add(loc.getWorld());
-            }
-            return worlds;
-        }
-        return getAcceptedWorlds(string);
-    }
-
-    private static List<World> getAcceptedWorlds(String string) {
-        List<World> worlds = new ArrayList<World>(Bukkit.getWorlds());
-        if (isInverted(string)) {
-            worlds.remove(getW(string));
-        } else {
-            worlds.clear();
-            worlds.add(getW(string));
-        }
-        return worlds;
-    }
-
-    private static boolean isTeam(String arg, Entity e) {
-        if (!(e instanceof Player))
-            return false;
-        for (Team t : Bukkit.getScoreboardManager().getMainScoreboard().getTeams()) {
-            if ((t.getName().equalsIgnoreCase(getTeam(arg)) != isInverted(arg))) {
-                if ((t.getEntries().contains(((Player) e).getName()) != isInverted(arg)))
-                    return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean isWithinPitch(String arg, Entity e) {
-        float pitch = getValueAsFloat(arg);
-        return isWithinDoubleValue(isInverted(arg), arg, e.getLocation().getPitch());
-    }
-
-    private static boolean isWithinYaw(String arg, Entity e) {
-        float pitch = getValueAsFloat(arg);
-        return isWithinDoubleValue(isInverted(arg), arg, e.getLocation().getYaw());
-    }
-
-    private static boolean isWithinDistance(String arg, Location start, Entity e) {
-        double distanceMin = 0;
-        double distanceMax = Double.MAX_VALUE;
-        String distance = arg.split("=")[1];
-        if (e.getLocation().getWorld() != start.getWorld())
-            return false;
-        if (distance.contains("..")) {
-            String[] temp = distance.split("\\.\\.");
-            if (!temp[0].isEmpty()) {
-                distanceMin = Integer.parseInt(temp[0]);
-            }
-            if (temp.length > 1 && !temp[1].isEmpty()) {
-                distanceMax = Double.parseDouble(temp[1]);
-            }
-            double actDis = start.distanceSquared(e.getLocation());
-            return actDis <= distanceMax * distanceMax && distanceMin * distanceMin <= actDis;
-        } else {
-            int mult = Integer.parseInt(distance);
-            mult *= mult;
-            return ((int) start.distanceSquared(e.getLocation())) == mult;
-        }
-    }
-
-    private static boolean isWithinLevel(String arg, Entity e) {
-        if (!(e instanceof Player))
-            return false;
-        double distanceMin = 0;
-        double distanceMax = Double.MAX_VALUE;
-        String distance = arg.split("=")[1];
-        if (distance.contains("..")) {
-            String[] temp = distance.split("..");
-            if (!temp[0].isEmpty()) {
-                distanceMin = Integer.parseInt(temp[0]);
-            }
-            if (temp[1] != null && !temp[1].isEmpty()) {
-                distanceMax = Double.parseDouble(temp[1]);
-            }
-            double actDis = ((Player) e).getExpToLevel();
-            return actDis <= distanceMax * distanceMax && distanceMin * distanceMin <= actDis;
-        } else {
-            return ((Player) e).getExpToLevel() == Integer.parseInt(distance);
-        }
-    }
-
-    private static boolean isScore(String arg, Entity e) {
-        if (!(e instanceof Player))
-            return false;
-        for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard().getObjectives()) {
-            if (o.getName().equalsIgnoreCase(getScoreName(arg))) {
-                if ((o.getScore(((Player) e).getName()).getScore() <= getValueAsInteger(arg) != isInverted(arg)))
-                    return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean isScoreWithin(String arg, Entity e) {
-        if (!(e instanceof Player))
-            return false;
-        String[] scores = arg.split("\\{")[1].split("\\}")[0].split(",");
-        for (int i = 0; i < scores.length; i++) {
-            String[] s = scores[i].split("=");
-            String name = s[0];
-
-            for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard().getObjectives()) {
-                if (o.getName().equalsIgnoreCase(name)) {
-                    if (!isWithinDoubleValue(isInverted(arg), s[1], o.getScore(e.getName()).getScore()))
-                        return false;
-                }
-            }
-        }
-        return true;
-
-    }
-
-    private static boolean isHasTags(String arg, Entity e) {
-        if (!(e instanceof Player))
-            return false;
-        return isInverted(arg) != e.getScoreboardTags().contains(getString(arg));
-
-    }
-
-    private static boolean isScoreMin(String arg, Entity e) {
-        if (!(e instanceof Player))
-            return false;
-        for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard().getObjectives()) {
-            if (o.getName().equalsIgnoreCase(getScoreMinName(arg))) {
-                if ((o.getScore(((Player) e).getName()).getScore() >= getValueAsInteger(arg) != isInverted(arg)))
-                    return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean isRM(String arg, Location loc, Entity e) {
-        if (loc.getWorld() != e.getWorld())
-            return false;
-        return isGreaterThan(arg, loc.distance(e.getLocation()));
-    }
-
-    private static boolean isR(String arg, Location loc, Entity e) {
-        if (loc.getWorld() != e.getWorld())
-            return false;
-        return isLessThan(arg, loc.distance(e.getLocation()));
-
-    }
-
-    private static boolean isRXM(String arg, Entity e) {
-        return isLessThan(arg, e.getLocation().getYaw());
-    }
-
-    private static boolean isRX(String arg, Entity e) {
-        return isGreaterThan(arg, e.getLocation().getYaw());
-    }
-
-    private static boolean isRYM(String arg, Entity e) {
-        return isLessThan(arg, e.getLocation().getPitch());
-    }
-
-    private static boolean isRY(String arg, Entity e) {
-        return isGreaterThan(arg, e.getLocation().getPitch());
-    }
-
-    private static boolean isL(String arg, Entity e) {
-        if (e instanceof Player) {
-            isLessThan(arg, ((Player) e).getTotalExperience());
-        }
-        return false;
-    }
-
-    private static boolean isLM(String arg, Entity e) {
-        if (e instanceof Player) {
-            return isGreaterThan(arg, ((Player) e).getTotalExperience());
-        }
-        return false;
-    }
-
-    private static boolean isH(String arg, Entity e) {
-        if (e instanceof Damageable)
-            return isGreaterThan(arg, ((Damageable) e).getHealth());
-        return false;
-    }
-
-    private static boolean isHM(String arg, Entity e) {
-        if (e instanceof Damageable)
-            return isLessThan(arg, ((Damageable) e).getHealth());
-        return false;
-    }
-
-    private static boolean isM(String arg, Entity e) {
-        if (getM(arg) == null)
-            return true;
-        if (e instanceof HumanEntity) {
-            if ((isInverted(arg) != (getM(arg) == ((HumanEntity) e).getGameMode())))
-                return true;
-        }
-        return false;
-    }
-
-    private static boolean isW(String arg, Location loc, Entity e) {
-        if (getW(arg) == null) {
-            return true;
-        } else if ((isInverted(arg) != getAcceptedWorlds(arg).contains(getW(arg))))
-            return true;
-        return false;
-    }
-
-    private static boolean isName(String arg, Entity e) {
-        if (getName(arg) == null)
-            return true;
-        if ((isInverted(arg) != (e.getCustomName() != null) && isInverted(arg) != (getName(arg)
-                .equals(e.getCustomName().replace(" ", "_"))
-                || (e instanceof Player && ((Player) e).getName().replace(" ", "_").equalsIgnoreCase(getName(arg))))))
-            return true;
-        return false;
-    }
-
-    private static boolean isType(String arg, Entity e) {
-        boolean invert = isInverted(arg);
-        String type = getType(arg);
-        if (invert != e.getType().name().equalsIgnoreCase(type))
-            return true;
-        return false;
-
-    }
-
-    private static boolean isInverted(String arg) {
-        return arg.toLowerCase().split("!").length != 1;
-    }
-
-    private static int getInt(String arg) {
-        int mult = Integer.parseInt(arg.split("=")[1]);
-        return mult;
-    }
-
-    public static String getString(String arg) {
-        return arg.split("=")[1].replaceAll("!", "");
-    }
-
-    private static boolean isLessThan(String arg, double value) {
-        boolean inverted = isInverted(arg);
-        double mult = Double.parseDouble(arg.split("=")[1]);
-        return (value < mult) != inverted;
-    }
-
-    private static boolean isGreaterThan(String arg, double value) {
-        boolean inverted = isInverted(arg);
-        double mult = Double.parseDouble(arg.split("=")[1]);
-        return (value > mult) != inverted;
-    }
-
-    private static boolean isWithinDoubleValue(boolean inverted, String arg, double value) {
-        double min = -Double.MAX_VALUE;
-        double max = Double.MAX_VALUE;
-        if (arg.contains("..")) {
-            String[] temp = arg.split("\\.\\.");
-            if (!temp[0].isEmpty()) {
-                min = Integer.parseInt(temp[0]);
-            }
-            if (temp.length > 1 && !temp[1].isEmpty()) {
-                max = Double.parseDouble(temp[1]);
-            }
-            return (value <= max * max && min * min <= value) != inverted;
-        } else {
-            double mult = Double.parseDouble(arg);
-            return (value == mult) != inverted;
-        }
-    }
-
-    private static boolean hasTag(SelectorType type, String arg) {
-        return arg.toLowerCase().startsWith(type.getName());
-    }
-
-    enum SelectorType {
-        LEVEL("level="), DISTANCE("distance="), TYPE("type="), NAME("name="), TEAM("team="), LMax("lm="), L(
-                "l="), World("w="), m("m="), C("c="), HM("hm="), H("h="), RM("rm="), RYM("rym="), RX("rx="), SCORE_FULL(
-                "score="), SCORE_MIN("score_min"), SCORE_13(
-                "scores="), R("r="), RXM("rxm="), RY("ry="), TAG("tag="), X("x="), Y("y="), Z("z="), LIMIT("limit="), Y_ROTATION("y_rotation"), X_ROTATION("x_rotation");
-        String name;
-
-        SelectorType(String s) {
-            this.name = s;
-        }
-
-        public String getName() {
-            return name;
-        }
-    }
+	/**
+	 * The CommandUtils class is used for selector support in commands (@p, @a etc.) Originally made by ZombieStriker
+	 * https://github.com/ZombieStriker/PsudoCommands/blob/master/src/me/zombie_striker/psudocommands/CommandUtils.java
+	 * https://github.com/ZombieStriker/CommandUtils/blob/master/src/CommandUtils.java
+	 */
+
+	/**
+	 * Use this if you are unsure if a player provided the "@a" tag. This will allow multiple entities to be retrieved.
+	 * <p>
+	 * This can return a null variable if no tags are included, or if a value for a tag does not exist (I.e if the tag
+	 * [type=___] contains an entity that does not exist in the specified world)
+	 * <p>
+	 * The may also be empty or null values at the end of the array. Once a null value has been reached, you do not need
+	 * to loop through any of the higher indexes
+	 * <p>
+	 * Currently supports the tags:
+	 *
+	 * @param arg the argument that we are testing for
+	 * @param sender the sender of the command
+	 * @return The entities that match the criteria
+	 * @p , @a , @e , @r
+	 *    <p>
+	 *    Currently supports the selectors: [type=] [r=] [rm=] [c=] [w=] [m=] [name=] [l=] [lm=] [h=] [hm=] [rx=] [rxm=]
+	 *    [ry=] [rym=] [team=] [score_---=] [score_---_min=] [x] [y] [z] [limit=] [x_rotation] [y_rotation]
+	 *    <p>
+	 *    All selectors can be inverted.
+	 */
+	public static Entity[] getTargets(CommandSender sender, String arg) {
+		Entity[] ents;
+		Location loc = null;
+		if (sender instanceof Player) {
+			loc = ((Player) sender).getLocation();
+		} else if (sender instanceof BlockCommandSender) {
+			// Center of block.
+			loc = ((BlockCommandSender) sender).getBlock().getLocation().add(0.5, 0, 0.5);
+		} else if (sender instanceof CommandMinecart) {
+			loc = ((CommandMinecart) sender).getLocation();
+		}
+		String[] tags = getTags(arg);
+
+		// prefab fix
+		for (String s : tags) {
+			if (hasTag(SelectorType.X, s)) {
+				loc.setX(getInt(s));
+			} else if (hasTag(SelectorType.Y, s)) {
+				loc.setY(getInt(s));
+			} else if (hasTag(SelectorType.Z, s)) {
+				loc.setZ(getInt(s));
+			}
+		}
+
+		if (arg.startsWith("@s")) {
+			ents = new Entity[1];
+			if (sender instanceof Player) {
+				boolean good = true;
+				for (int b = 0; b < tags.length; b++) {
+					if (!canBeAccepted(tags[b], (Entity) sender, loc)) {
+						good = false;
+						break;
+					}
+				}
+				if (good) {
+					ents[0] = (Entity) sender;
+				}
+			} else {
+				return null;
+			}
+			return ents;
+		} else if (arg.startsWith("@a")) {
+			// ents = new Entity[maxEnts];
+			List<Entity> listOfValidEntities = new ArrayList<>();
+			int C = getLimit(arg);
+
+			boolean usePlayers = true;
+			for (String tag : tags) {
+				if (hasTag(SelectorType.TYPE, tag)) {
+					usePlayers = false;
+					break;
+				}
+			}
+			List<Entity> ea = new ArrayList<Entity>(Bukkit.getOnlinePlayers());
+			if (!usePlayers) {
+				ea.clear();
+				for (World w : getAcceptedWorldsFullString(loc, arg)) {
+					ea.addAll(w.getEntities());
+				}
+			}
+			for (Entity e : ea) {
+				if (listOfValidEntities.size() >= C)
+					break;
+				boolean isValid = true;
+				for (int b = 0; b < tags.length; b++) {
+					if (!canBeAccepted(tags[b], e, loc)) {
+						isValid = false;
+						break;
+					}
+				}
+				if (isValid) {
+					listOfValidEntities.add(e);
+				}
+			}
+
+			ents = listOfValidEntities.toArray(new Entity[listOfValidEntities.size()]);
+
+		} else if (arg.startsWith("@p")) {
+			ents = new Entity[1];
+			double closestInt = Double.MAX_VALUE;
+			Entity closest = null;
+
+			for (World w : getAcceptedWorldsFullString(loc, arg)) {
+				for (Player e : w.getPlayers()) {
+					if (e == sender)
+						continue;
+					Location temp = loc;
+					if (temp == null)
+						temp = e.getWorld().getSpawnLocation();
+					double distance = e.getLocation().distanceSquared(temp);
+					if (closestInt > distance) {
+						boolean good = true;
+						for (String tag : tags) {
+							if (!canBeAccepted(tag, e, temp)) {
+								good = false;
+								break;
+							}
+						}
+						if (good) {
+							closestInt = distance;
+							closest = e;
+						}
+					}
+				}
+			}
+			ents[0] = closest;
+		} else if (arg.startsWith("@e")) {
+			List<Entity> entities = new ArrayList<Entity>();
+			int C = getLimit(arg);
+			for (World w : getAcceptedWorldsFullString(loc, arg)) {
+				for (Entity e : w.getEntities()) {
+					if (entities.size() > C)
+						break;
+					if (e == sender)
+						continue;
+					boolean valid = true;
+					for (String tag : tags) {
+						if (!canBeAccepted(tag, e, loc)) {
+							valid = false;
+							break;
+						}
+					}
+					if (valid) {
+						entities.add(e);
+					}
+				}
+			}
+			ents = entities.toArray(new Entity[entities.size()]);
+		} else if (arg.startsWith("@r")) {
+			Random r = ThreadLocalRandom.current();
+			ents = new Entity[1];
+
+			List<Entity> validEntities = new ArrayList<>();
+			for (World w : getAcceptedWorldsFullString(loc, arg)) {
+				if (hasTag(SelectorType.TYPE, arg)) {
+					for (Entity e : w.getEntities()) {
+						boolean good = true;
+						for (String tag : tags) {
+							if (!canBeAccepted(tag, e, loc)) {
+								good = false;
+								break;
+							}
+						}
+						if (good)
+							validEntities.add(e);
+					}
+				} else {
+					for (Entity e : Bukkit.getOnlinePlayers()) {
+						boolean good = true;
+						for (String tag : tags) {
+							if (!canBeAccepted(tag, e, loc)) {
+								good = false;
+								break;
+							}
+						}
+						if (good)
+							validEntities.add(e);
+					}
+				}
+			}
+			ents[0] = validEntities.get(r.nextInt(validEntities.size()));
+		} else {
+			ents = new Entity[] { Bukkit.getPlayer(arg) };
+		}
+		return ents;
+	}
+
+	/**
+	 * Returns one entity. Use this if you know the player will not provide the '@a' tag.
+	 * <p>
+	 * This can return a null variable if no tags are included, or if a value for a tag does not exist (I.e if the tag
+	 * [type=___] contains an entity that does not exist in the specified world)
+	 *
+	 * @param sender the command sender
+	 * @param arg the argument of the target
+	 * @return The first entity retrieved.
+	 */
+	public static Entity getTarget(CommandSender sender, String arg) {
+		Entity[] e = getTargets(sender, arg);
+		if (e.length == 0)
+			return null;
+		return e[0];
+	}
+
+	/**
+	 * Returns an integer. Use this to support "~" by providing what it will mean.
+	 * <p>
+	 * E.g. rel="x" when ~ should be turn into the entity's X coord.
+	 * <p>
+	 * Currently supports "x", "y" and "z".
+	 *
+	 * @param arg The target
+	 * @param rel relative to the X,Y, or Z
+	 * @param e The entity to check relative to.
+	 * @return the int
+	 */
+	public static int getIntRelative(String arg, String rel, Entity e) {
+		int relInt = 0;
+		if (arg.startsWith("~")) {
+			switch (rel.toLowerCase()) {
+				case "x":
+					relInt = e.getLocation().getBlockX();
+					break;
+				case "y":
+					relInt = e.getLocation().getBlockY();
+					break;
+				case "z":
+					relInt = e.getLocation().getBlockZ();
+					break;
+			}
+			return mathIt(arg, relInt);
+		} else if (arg.startsWith("^")) {
+			// TODO: Fix code. The currently just acts the same as ~. This should move the
+			// entity relative to what its looking at.
+
+			switch (rel.toLowerCase()) {
+				case "x":
+					relInt = e.getLocation().getBlockX();
+					break;
+				case "y":
+					relInt = e.getLocation().getBlockY();
+					break;
+				case "z":
+					relInt = e.getLocation().getBlockZ();
+					break;
+			}
+			return mathIt(arg, relInt);
+		}
+		return 0;
+	}
+
+	private static boolean canBeAccepted(String arg, Entity e, Location loc) {
+		if (hasTag(SelectorType.X_ROTATION, arg) && isWithinYaw(arg, e))
+			return true;
+		if (hasTag(SelectorType.Y_ROTATION, arg) && isWithinPitch(arg, e))
+			return true;
+		if (hasTag(SelectorType.TYPE, arg) && isType(arg, e))
+			return true;
+		if (hasTag(SelectorType.NAME, arg) && isName(arg, e))
+			return true;
+		if (hasTag(SelectorType.TEAM, arg) && isTeam(arg, e))
+			return true;
+		if (hasTag(SelectorType.SCORE_FULL, arg) && isScore(arg, e))
+			return true;
+		if (hasTag(SelectorType.SCORE_MIN, arg) && isScoreMin(arg, e))
+			return true;
+		if (hasTag(SelectorType.SCORE_13, arg) && isScoreWithin(arg, e))
+			return true;
+		if (hasTag(SelectorType.DISTANCE, arg) && isWithinDistance(arg, loc, e))
+			return true;
+		if (hasTag(SelectorType.LEVEL, arg) && isWithinLevel(arg, e))
+			return true;
+		if (hasTag(SelectorType.TAG, arg) && isHasTags(arg, e))
+			return true;
+		if (hasTag(SelectorType.RYM, arg) && isRYM(arg, e))
+			return true;
+		if (hasTag(SelectorType.RXM, arg) && isRXM(arg, e))
+			return true;
+		if (hasTag(SelectorType.HM, arg) && isHM(arg, e))
+			return true;
+		if (hasTag(SelectorType.RY, arg) && isRY(arg, e))
+			return true;
+		if (hasTag(SelectorType.RX, arg) && isRX(arg, e))
+			return true;
+		if (hasTag(SelectorType.RM, arg) && isRM(arg, loc, e))
+			return true;
+		if (hasTag(SelectorType.LMax, arg) && isLM(arg, e))
+			return true;
+		if (hasTag(SelectorType.L, arg) && isL(arg, e))
+			return true;
+		if (hasTag(SelectorType.m, arg) && isM(arg, e))
+			return true;
+		if (hasTag(SelectorType.H, arg) && isH(arg, e))
+			return true;
+		if (hasTag(SelectorType.World, arg) && isW(arg, loc, e))
+			return true;
+		if (hasTag(SelectorType.R, arg) && isR(arg, loc, e))
+			return true;
+		if (hasTag(SelectorType.X, arg))
+			return true;
+		if (hasTag(SelectorType.Y, arg))
+			return true;
+		if (hasTag(SelectorType.Z, arg))
+			return true;
+		return false;
+	}
+
+	private static String[] getTags(String arg) {
+		if (!arg.contains("["))
+			return new String[0];
+		String tags = arg.split("\\[")[1].split("\\]")[0];
+		return tags.split(",");
+	}
+
+	private static int mathIt(String args, int relInt) {
+		int total = 0;
+		short mode = 0;
+		String arg = args.replace("~", String.valueOf(relInt));
+		String intString = "";
+		for (int i = 0; i < arg.length(); i++) {
+			if (arg.charAt(i) == '+' || arg.charAt(i) == '-' || arg.charAt(i) == '*' || arg.charAt(i) == '/') {
+				try {
+					switch (mode) {
+						case 0:
+							total = total + Integer.parseInt(intString);
+							break;
+						case 1:
+							total = total - Integer.parseInt(intString);
+							break;
+						case 2:
+							total = total * Integer.parseInt(intString);
+							break;
+						case 3:
+							total = total / Integer.parseInt(intString);
+							break;
+					}
+					mode = (short) ((arg.charAt(i) == '+') ? 0
+							: ((arg.charAt(i) == '-') ? 1
+									: ((arg.charAt(i) == '*') ? 2 : ((arg.charAt(i) == '/') ? 3 : -1))));
+				} catch (Exception e) {
+					Bukkit.getLogger().severe("There has been an issue with a plugin using the CommandUtils class!");
+				}
+
+			} else if (args.length() == i || arg.charAt(i) == ' ' || arg.charAt(i) == ',' || arg.charAt(i) == ']') {
+				try {
+					switch (mode) {
+						case 0:
+							total = total + Integer.parseInt(intString);
+							break;
+						case 1:
+							total = total - Integer.parseInt(intString);
+							break;
+						case 2:
+							total = total * Integer.parseInt(intString);
+							break;
+						case 3:
+							total = total / Integer.parseInt(intString);
+							break;
+					}
+				} catch (Exception e) {
+					Bukkit.getLogger().severe("There has been an issue with a plugin using the CommandUtils class!");
+				}
+				break;
+			} else {
+				intString += arg.charAt(i);
+			}
+		}
+		return total;
+	}
+
+	private static int getLimit(String arg) {
+		if (hasTag(SelectorType.LIMIT, arg))
+			for (String s : getTags(arg)) {
+				if (hasTag(SelectorType.LIMIT, s)) {
+					return getInt(s);
+				}
+			}
+		if (hasTag(SelectorType.C, arg))
+			for (String s : getTags(arg)) {
+				if (hasTag(SelectorType.C, s)) {
+					return getInt(s);
+				}
+			}
+		return Integer.MAX_VALUE;
+	}
+
+	private static String getType(String arg) {
+		if (hasTag(SelectorType.TYPE, arg))
+			return arg.toLowerCase().split("=")[1].replace("!", "");
+		return "Player";
+	}
+
+	private static String getName(String arg) {
+		String reparg = arg.replace(" ", "_");
+		return reparg.replace("!", "").split("=")[1];
+	}
+
+	private static World getW(String arg) {
+		return Bukkit.getWorld(getString(arg));
+	}
+
+	private static String getScoreMinName(String arg) {
+		return arg.split("=")[0].substring(0, arg.split("=")[0].length() - 1 - 4).replace("score_", "");
+	}
+
+	private static String getScoreName(String arg) {
+		return arg.split("=")[0].replace("score_", "");
+	}
+
+	private static String getTeam(String arg) {
+		return arg.toLowerCase().replace("!", "").split("=")[1];
+	}
+
+	private static float getValueAsFloat(String arg) {
+		return Float.parseFloat(arg.replace("!", "").split("=")[1]);
+	}
+
+	private static int getValueAsInteger(String arg) {
+		return Integer.parseInt(arg.replace("!", "").split("=")[1]);
+	}
+
+	private static GameMode getM(String arg) {
+		String[] split = arg.replace("!", "").toLowerCase().split("=");
+		String returnType = split[1];
+		if (returnType.equalsIgnoreCase("0") || returnType.equalsIgnoreCase("s")
+				|| returnType.equalsIgnoreCase("survival"))
+			return GameMode.SURVIVAL;
+		if (returnType.equalsIgnoreCase("1") || returnType.equalsIgnoreCase("c")
+				|| returnType.equalsIgnoreCase("creative"))
+			return GameMode.CREATIVE;
+		if (returnType.equalsIgnoreCase("2") || returnType.equalsIgnoreCase("a")
+				|| returnType.equalsIgnoreCase("adventure"))
+			return GameMode.ADVENTURE;
+		if (returnType.equalsIgnoreCase("3") || returnType.equalsIgnoreCase("sp")
+				|| returnType.equalsIgnoreCase("spectator"))
+			return GameMode.SPECTATOR;
+		return null;
+	}
+
+	private static List<World> getAcceptedWorldsFullString(Location loc, String fullString) {
+		String string = null;
+		for (String tag : getTags(fullString)) {
+			if (hasTag(SelectorType.World, tag)) {
+				string = tag;
+				break;
+			}
+		}
+		if (string == null) {
+			List<World> worlds = new ArrayList<World>();
+			if (loc == null || loc.getWorld() == null) {
+				worlds.addAll(Bukkit.getWorlds());
+			} else {
+				worlds.add(loc.getWorld());
+			}
+			return worlds;
+		}
+		return getAcceptedWorlds(string);
+	}
+
+	private static List<World> getAcceptedWorlds(String string) {
+		List<World> worlds = new ArrayList<World>(Bukkit.getWorlds());
+		if (isInverted(string)) {
+			worlds.remove(getW(string));
+		} else {
+			worlds.clear();
+			worlds.add(getW(string));
+		}
+		return worlds;
+	}
+
+	private static boolean isTeam(String arg, Entity e) {
+		if (!(e instanceof Player))
+			return false;
+		for (Team t : Bukkit.getScoreboardManager().getMainScoreboard().getTeams()) {
+			if ((t.getName().equalsIgnoreCase(getTeam(arg)) != isInverted(arg))) {
+				if ((t.getEntries().contains(((Player) e).getName()) != isInverted(arg)))
+					return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isWithinPitch(String arg, Entity e) {
+		float pitch = getValueAsFloat(arg);
+		return isWithinDoubleValue(isInverted(arg), arg, e.getLocation().getPitch());
+	}
+
+	private static boolean isWithinYaw(String arg, Entity e) {
+		float pitch = getValueAsFloat(arg);
+		return isWithinDoubleValue(isInverted(arg), arg, e.getLocation().getYaw());
+	}
+
+	private static boolean isWithinDistance(String arg, Location start, Entity e) {
+		double distanceMin = 0;
+		double distanceMax = Double.MAX_VALUE;
+		String distance = arg.split("=")[1];
+		if (e.getLocation().getWorld() != start.getWorld())
+			return false;
+		if (distance.contains("..")) {
+			String[] temp = distance.split("\\.\\.");
+			if (!temp[0].isEmpty()) {
+				distanceMin = Integer.parseInt(temp[0]);
+			}
+			if (temp.length > 1 && !temp[1].isEmpty()) {
+				distanceMax = Double.parseDouble(temp[1]);
+			}
+			double actDis = start.distanceSquared(e.getLocation());
+			return actDis <= distanceMax * distanceMax && distanceMin * distanceMin <= actDis;
+		} else {
+			int mult = Integer.parseInt(distance);
+			mult *= mult;
+			return ((int) start.distanceSquared(e.getLocation())) == mult;
+		}
+	}
+
+	private static boolean isWithinLevel(String arg, Entity e) {
+		if (!(e instanceof Player))
+			return false;
+		double distanceMin = 0;
+		double distanceMax = Double.MAX_VALUE;
+		String distance = arg.split("=")[1];
+		if (distance.contains("..")) {
+			String[] temp = distance.split("..");
+			if (!temp[0].isEmpty()) {
+				distanceMin = Integer.parseInt(temp[0]);
+			}
+			if (temp[1] != null && !temp[1].isEmpty()) {
+				distanceMax = Double.parseDouble(temp[1]);
+			}
+			double actDis = ((Player) e).getExpToLevel();
+			return actDis <= distanceMax * distanceMax && distanceMin * distanceMin <= actDis;
+		} else {
+			return ((Player) e).getExpToLevel() == Integer.parseInt(distance);
+		}
+	}
+
+	private static boolean isScore(String arg, Entity e) {
+		if (!(e instanceof Player))
+			return false;
+		for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard().getObjectives()) {
+			if (o.getName().equalsIgnoreCase(getScoreName(arg))) {
+				if ((o.getScore(((Player) e).getName()).getScore() <= getValueAsInteger(arg) != isInverted(arg)))
+					return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isScoreWithin(String arg, Entity e) {
+		if (!(e instanceof Player))
+			return false;
+		String[] scores = arg.split("\\{")[1].split("\\}")[0].split(",");
+		for (int i = 0; i < scores.length; i++) {
+			String[] s = scores[i].split("=");
+			String name = s[0];
+
+			for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard().getObjectives()) {
+				if (o.getName().equalsIgnoreCase(name)) {
+					if (!isWithinDoubleValue(isInverted(arg), s[1], o.getScore(e.getName()).getScore()))
+						return false;
+				}
+			}
+		}
+		return true;
+
+	}
+
+	private static boolean isHasTags(String arg, Entity e) {
+		if (!(e instanceof Player))
+			return false;
+		return isInverted(arg) != e.getScoreboardTags().contains(getString(arg));
+
+	}
+
+	private static boolean isScoreMin(String arg, Entity e) {
+		if (!(e instanceof Player))
+			return false;
+		for (Objective o : Bukkit.getScoreboardManager().getMainScoreboard().getObjectives()) {
+			if (o.getName().equalsIgnoreCase(getScoreMinName(arg))) {
+				if ((o.getScore(((Player) e).getName()).getScore() >= getValueAsInteger(arg) != isInverted(arg)))
+					return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isRM(String arg, Location loc, Entity e) {
+		if (loc.getWorld() != e.getWorld())
+			return false;
+		return isGreaterThan(arg, loc.distance(e.getLocation()));
+	}
+
+	private static boolean isR(String arg, Location loc, Entity e) {
+		if (loc.getWorld() != e.getWorld())
+			return false;
+		return isLessThan(arg, loc.distance(e.getLocation()));
+
+	}
+
+	private static boolean isRXM(String arg, Entity e) {
+		return isLessThan(arg, e.getLocation().getYaw());
+	}
+
+	private static boolean isRX(String arg, Entity e) {
+		return isGreaterThan(arg, e.getLocation().getYaw());
+	}
+
+	private static boolean isRYM(String arg, Entity e) {
+		return isLessThan(arg, e.getLocation().getPitch());
+	}
+
+	private static boolean isRY(String arg, Entity e) {
+		return isGreaterThan(arg, e.getLocation().getPitch());
+	}
+
+	private static boolean isL(String arg, Entity e) {
+		if (e instanceof Player) {
+			isLessThan(arg, ((Player) e).getTotalExperience());
+		}
+		return false;
+	}
+
+	private static boolean isLM(String arg, Entity e) {
+		if (e instanceof Player) {
+			return isGreaterThan(arg, ((Player) e).getTotalExperience());
+		}
+		return false;
+	}
+
+	private static boolean isH(String arg, Entity e) {
+		if (e instanceof Damageable)
+			return isGreaterThan(arg, ((Damageable) e).getHealth());
+		return false;
+	}
+
+	private static boolean isHM(String arg, Entity e) {
+		if (e instanceof Damageable)
+			return isLessThan(arg, ((Damageable) e).getHealth());
+		return false;
+	}
+
+	private static boolean isM(String arg, Entity e) {
+		if (getM(arg) == null)
+			return true;
+		if (e instanceof HumanEntity) {
+			if ((isInverted(arg) != (getM(arg) == ((HumanEntity) e).getGameMode())))
+				return true;
+		}
+		return false;
+	}
+
+	private static boolean isW(String arg, Location loc, Entity e) {
+		if (getW(arg) == null) {
+			return true;
+		} else if ((isInverted(arg) != getAcceptedWorlds(arg).contains(getW(arg))))
+			return true;
+		return false;
+	}
+
+	private static boolean isName(String arg, Entity e) {
+		if (getName(arg) == null)
+			return true;
+		if ((isInverted(arg) != (e.getCustomName() != null) && isInverted(arg) != (getName(arg)
+				.equals(e.getCustomName().replace(" ", "_"))
+				|| (e instanceof Player && ((Player) e).getName().replace(" ", "_").equalsIgnoreCase(getName(arg))))))
+			return true;
+		return false;
+	}
+
+	private static boolean isType(String arg, Entity e) {
+		boolean invert = isInverted(arg);
+		String type = getType(arg);
+		if (invert != e.getType().name().equalsIgnoreCase(type))
+			return true;
+		return false;
+
+	}
+
+	private static boolean isInverted(String arg) {
+		return arg.toLowerCase().split("!").length != 1;
+	}
+
+	private static int getInt(String arg) {
+		int mult = Integer.parseInt(arg.split("=")[1]);
+		return mult;
+	}
+
+	public static String getString(String arg) {
+		return arg.split("=")[1].replaceAll("!", "");
+	}
+
+	private static boolean isLessThan(String arg, double value) {
+		boolean inverted = isInverted(arg);
+		double mult = Double.parseDouble(arg.split("=")[1]);
+		return (value < mult) != inverted;
+	}
+
+	private static boolean isGreaterThan(String arg, double value) {
+		boolean inverted = isInverted(arg);
+		double mult = Double.parseDouble(arg.split("=")[1]);
+		return (value > mult) != inverted;
+	}
+
+	private static boolean isWithinDoubleValue(boolean inverted, String arg, double value) {
+		double min = -Double.MAX_VALUE;
+		double max = Double.MAX_VALUE;
+		if (arg.contains("..")) {
+			String[] temp = arg.split("\\.\\.");
+			if (!temp[0].isEmpty()) {
+				min = Integer.parseInt(temp[0]);
+			}
+			if (temp.length > 1 && !temp[1].isEmpty()) {
+				max = Double.parseDouble(temp[1]);
+			}
+			return (value <= max * max && min * min <= value) != inverted;
+		} else {
+			double mult = Double.parseDouble(arg);
+			return (value == mult) != inverted;
+		}
+	}
+
+	private static boolean hasTag(SelectorType type, String arg) {
+		return arg.toLowerCase().startsWith(type.getName());
+	}
+
+	enum SelectorType {
+
+		LEVEL("level="),
+		DISTANCE("distance="),
+		TYPE("type="),
+		NAME("name="),
+		TEAM("team="),
+		LMax("lm="),
+		L("l="),
+		World("w="),
+		m("m="),
+		C("c="),
+		HM("hm="),
+		H("h="),
+		RM("rm="),
+		RYM("rym="),
+		RX("rx="),
+		SCORE_FULL("score="),
+		SCORE_MIN("score_min"),
+		SCORE_13("scores="),
+		R("r="),
+		RXM("rxm="),
+		RY("ry="),
+		TAG("tag="),
+		X("x="),
+		Y("y="),
+		Z("z="),
+		LIMIT("limit="),
+		Y_ROTATION("y_rotation"),
+		X_ROTATION("x_rotation");
+
+		String name;
+
+		SelectorType(String s) {
+			this.name = s;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
 }

--- a/advanced-achievements-plugin/src/main/resources/lang.yml
+++ b/advanced-achievements-plugin/src/main/resources/lang.yml
@@ -38,7 +38,7 @@ book-not-received: "You have not yet received any achievements."
 
 # Related to /aach give.
 player-offline: "The player PLAYER is offline!"
-not-a-player: "You cannot give achievements to entities other than players!"
+not-a-player: "You cannot give achievements to ENTITY, it is not a player!"
 achievement-already-received: "The player PLAYER has already received this achievement!"
 achievement-not-found: "The specified achievement was not found in Commands category. Did you mean CLOSEST_MATCH?"
 achievement-given: "Achievement given!"

--- a/advanced-achievements-plugin/src/main/resources/lang.yml
+++ b/advanced-achievements-plugin/src/main/resources/lang.yml
@@ -38,6 +38,7 @@ book-not-received: "You have not yet received any achievements."
 
 # Related to /aach give.
 player-offline: "The player PLAYER is offline!"
+not-a-player: "You cannot give achievements to entities other than players!"
 achievement-already-received: "The player PLAYER has already received this achievement!"
 achievement-not-found: "The specified achievement was not found in Commands category. Did you mean CLOSEST_MATCH?"
 achievement-given: "Achievement given!"


### PR DESCRIPTION
This pull request adds support for selectors in commands like /aach give.
It allows users to execute commands like `/aach give <achievement> @p`, which will give the achievement to the nearest player, or  `/aach give <achievement> @a[r=20]`, which will give it to all players in a 20 block radius.
This is especially useful for custom achievements in combination with command blocks.
I have tested this in my Paper 1.14.2 (build 237) server.