### PR TITLE
Support for multiple items in rewards

### DIFF
--- a/advanced-achievements-api/src/main/java/com/hm/achievement/utils/PlayerAdvancedAchievementEvent.java
+++ b/advanced-achievements-api/src/main/java/com/hm/achievement/utils/PlayerAdvancedAchievementEvent.java
@@ -25,7 +25,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 	private final String message;
 	private final List<String> commandMessages;
 	private final String[] commandRewards;
-	private final ItemStack[] itemReward;
+	private final ItemStack[] itemRewards;
 	private final int moneyReward;
 	private final int experienceReward;
 	private final int maxHealthReward;
@@ -34,7 +34,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 	private boolean cancelled;
 
 	private PlayerAdvancedAchievementEvent(Player receiver, String name, String displayName, String message,
-			List<String> commandMessages, String[] commandRewards, ItemStack[] itemReward, int moneyReward,
+			List<String> commandMessages, String[] commandRewards, ItemStack[] itemRewards, int moneyReward,
 			int experienceReward, int maxHealthReward, int maxOxygenReward) {
 		player = receiver;
 		this.name = name;
@@ -42,7 +42,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 		this.message = message;
 		this.commandMessages = commandMessages;
 		this.commandRewards = commandRewards;
-		this.itemReward = itemReward;
+		this.itemRewards = itemRewards;
 		this.moneyReward = moneyReward;
 		this.experienceReward = experienceReward;
 		this.maxHealthReward = maxHealthReward;
@@ -99,8 +99,8 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 		return commandRewards;
 	}
 
-	public ItemStack[] getItemReward() {
-		return itemReward;
+	public ItemStack[] getItemRewards() {
+		return itemRewards;
 	}
 
 	public int getMoneyReward() {
@@ -127,7 +127,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 		private String message;
 		private List<String> commandMessage;
 		private String[] commandRewards;
-		private ItemStack[] itemReward;
+		private ItemStack[] itemRewards;
 		private int moneyReward;
 		private int experienceReward;
 		private int maxHealthReward;
@@ -172,8 +172,8 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 			return this;
 		}
 
-		public PlayerAdvancedAchievementEventBuilder itemReward(ItemStack[] itemReward) {
-			this.itemReward = itemReward;
+		public PlayerAdvancedAchievementEventBuilder itemRewards(ItemStack[] itemRewards) {
+			this.itemRewards = itemRewards;
 			return this;
 		}
 
@@ -199,7 +199,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 
 		public PlayerAdvancedAchievementEvent build() {
 			return new PlayerAdvancedAchievementEvent(player, name, displayName, message, commandMessage, commandRewards,
-					itemReward, moneyReward, experienceReward, maxHealthReward, maxOxygenReward);
+					itemRewards, moneyReward, experienceReward, maxHealthReward, maxOxygenReward);
 		}
 	}
 }

--- a/advanced-achievements-api/src/main/java/com/hm/achievement/utils/PlayerAdvancedAchievementEvent.java
+++ b/advanced-achievements-api/src/main/java/com/hm/achievement/utils/PlayerAdvancedAchievementEvent.java
@@ -99,6 +99,14 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 		return commandRewards;
 	}
 
+	/**
+	 * @deprecated use {@link #getItemRewards()} instead
+	 */
+	@Deprecated
+	public ItemStack getItemReward() {
+		return itemRewards == null || itemRewards.length == 0 ? null : itemRewards[0];
+	}
+
 	public ItemStack[] getItemRewards() {
 		return itemRewards;
 	}
@@ -172,6 +180,15 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #itemRewards(ItemStack[])} instead
+		 */
+		@Deprecated
+		public PlayerAdvancedAchievementEventBuilder itemReward(ItemStack itemReward) {
+			this.itemRewards = new ItemStack[]{ itemReward };
+			return this;
+		}
+		
 		public PlayerAdvancedAchievementEventBuilder itemRewards(ItemStack[] itemRewards) {
 			this.itemRewards = itemRewards;
 			return this;

--- a/advanced-achievements-api/src/main/java/com/hm/achievement/utils/PlayerAdvancedAchievementEvent.java
+++ b/advanced-achievements-api/src/main/java/com/hm/achievement/utils/PlayerAdvancedAchievementEvent.java
@@ -25,7 +25,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 	private final String message;
 	private final List<String> commandMessages;
 	private final String[] commandRewards;
-	private final ItemStack itemReward;
+	private final ItemStack[] itemReward;
 	private final int moneyReward;
 	private final int experienceReward;
 	private final int maxHealthReward;
@@ -34,7 +34,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 	private boolean cancelled;
 
 	private PlayerAdvancedAchievementEvent(Player receiver, String name, String displayName, String message,
-			List<String> commandMessages, String[] commandRewards, ItemStack itemReward, int moneyReward,
+			List<String> commandMessages, String[] commandRewards, ItemStack[] itemReward, int moneyReward,
 			int experienceReward, int maxHealthReward, int maxOxygenReward) {
 		player = receiver;
 		this.name = name;
@@ -99,7 +99,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 		return commandRewards;
 	}
 
-	public ItemStack getItemReward() {
+	public ItemStack[] getItemReward() {
 		return itemReward;
 	}
 
@@ -127,7 +127,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 		private String message;
 		private List<String> commandMessage;
 		private String[] commandRewards;
-		private ItemStack itemReward;
+		private ItemStack[] itemReward;
 		private int moneyReward;
 		private int experienceReward;
 		private int maxHealthReward;
@@ -172,7 +172,7 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 			return this;
 		}
 
-		public PlayerAdvancedAchievementEventBuilder itemReward(ItemStack itemReward) {
+		public PlayerAdvancedAchievementEventBuilder itemReward(ItemStack[] itemReward) {
 			this.itemReward = itemReward;
 			return this;
 		}

--- a/advanced-achievements-api/src/main/java/com/hm/achievement/utils/PlayerAdvancedAchievementEvent.java
+++ b/advanced-achievements-api/src/main/java/com/hm/achievement/utils/PlayerAdvancedAchievementEvent.java
@@ -185,10 +185,10 @@ public class PlayerAdvancedAchievementEvent extends Event implements Cancellable
 		 */
 		@Deprecated
 		public PlayerAdvancedAchievementEventBuilder itemReward(ItemStack itemReward) {
-			this.itemRewards = new ItemStack[]{ itemReward };
+			this.itemRewards = new ItemStack[] { itemReward };
 			return this;
 		}
-		
+
 		public PlayerAdvancedAchievementEventBuilder itemRewards(ItemStack[] itemRewards) {
 			this.itemRewards = itemRewards;
 			return this;

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/command/executable/GiveCommand.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/command/executable/GiveCommand.java
@@ -74,7 +74,7 @@ public class GiveCommand extends AbstractParsableCommand {
 					.message(mainConfig.getString(achievementPath + ".Message"))
 					.commandRewards(rewardParser.getCommandRewards(rewardPath, player))
 					.commandMessage(rewardParser.getCustomCommandMessages(rewardPath))
-					.itemReward(rewardParser.getItemReward(rewardPath, player))
+					.itemRewards(rewardParser.getItemRewards(rewardPath, player))
 					.moneyReward(rewardParser.getRewardAmount(rewardPath, "Money"))
 					.experienceReward(rewardParser.getRewardAmount(rewardPath, "Experience"))
 					.maxHealthReward(rewardParser.getRewardAmount(rewardPath, "IncreaseMaxHealth"))

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/PlayerAdvancedAchievementListener.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/PlayerAdvancedAchievementListener.java
@@ -177,7 +177,7 @@ public class PlayerAdvancedAchievementListener implements Listener, Reloadable {
 		databaseManager.registerAchievement(player.getUniqueId(), event.getName(), event.getMessage());
 
 		List<String> rewardTexts = giveRewardsAndPrepareTexts(player, event.getCommandRewards(), event.getCommandMessages(),
-				event.getItemReward(), event.getMoneyReward(), event.getExperienceReward(), event.getMaxHealthReward(),
+				event.getItemRewards(), event.getMoneyReward(), event.getExperienceReward(), event.getMaxHealthReward(),
 				event.getMaxOxygenReward());
 		displayAchievement(player, event.getName(), event.getDisplayName(), event.getMessage(), rewardTexts);
 
@@ -250,12 +250,12 @@ public class PlayerAdvancedAchievementListener implements Listener, Reloadable {
 	 * Gives an item reward to a player.
 	 *
 	 * @param player
-	 * @param itemArray
+	 * @param items
 	 * @return the reward text to display to the player
 	 */
-	private List<String> rewardItem(Player player, ItemStack[] itemArray) {
+	private List<String> rewardItem(Player player, ItemStack[] items) {
 		List<String> itemNames = new ArrayList<>();
-		for (ItemStack item : itemArray) {
+		for (ItemStack item : items) {
 			if (player.getInventory().firstEmpty() != -1) {
 				player.getInventory().addItem(item);
 			} else {
@@ -529,7 +529,7 @@ public class PlayerAdvancedAchievementListener implements Listener, Reloadable {
 		List<String> rewardTexts = giveRewardsAndPrepareTexts(player,
 				rewardParser.getCommandRewards("AllAchievementsReceivedRewards", player),
 				rewardParser.getCustomCommandMessages("AllAchievementsReceivedRewards"),
-				rewardParser.getItemReward("AllAchievementsReceivedRewards", player),
+				rewardParser.getItemRewards("AllAchievementsReceivedRewards", player),
 				rewardParser.getRewardAmount("AllAchievementsReceivedRewards", "Money"),
 				rewardParser.getRewardAmount("AllAchievementsReceivedRewards", "Experience"),
 				rewardParser.getRewardAmount("AllAchievementsReceivedRewards", "IncreaseMaxHealth"),

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/PlayerAdvancedAchievementListener.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/PlayerAdvancedAchievementListener.java
@@ -200,13 +200,13 @@ public class PlayerAdvancedAchievementListener implements Listener, Reloadable {
 	 * @return all the reward texts to be displayed to the user
 	 */
 	private List<String> giveRewardsAndPrepareTexts(Player player, String[] commands, List<String> commandMessages,
-			ItemStack item, int money, int experience, int health, int oxygen) {
+													ItemStack[] item, int money, int experience, int health, int oxygen) {
 		List<String> rewardTexts = new ArrayList<>();
 		if (commands != null && commands.length > 0) {
 			rewardTexts.addAll(rewardCommands(commands, commandMessages));
 		}
 		if (item != null) {
-			rewardTexts.add(rewardItem(player, item));
+			rewardTexts.addAll(rewardItem(player, item));
 		}
 		if (money != 0) {
 			rewardTexts.add(rewardMoney(player, money));
@@ -250,19 +250,23 @@ public class PlayerAdvancedAchievementListener implements Listener, Reloadable {
 	 * Gives an item reward to a player.
 	 *
 	 * @param player
-	 * @param item
+	 * @param itemArray
 	 * @return the reward text to display to the player
 	 */
-	private String rewardItem(Player player, ItemStack item) {
-		if (player.getInventory().firstEmpty() != -1) {
-			player.getInventory().addItem(item);
-		} else {
-			player.getWorld().dropItem(player.getLocation(), item);
+	private List<String> rewardItem(Player player, ItemStack[] itemArray) {
+		List<String> itemNames = new ArrayList<>();
+		for (ItemStack item : itemArray) {
+			if (player.getInventory().firstEmpty() != -1) {
+				player.getInventory().addItem(item);
+			} else {
+				player.getWorld().dropItem(player.getLocation(), item);
+			}
+			ItemMeta itemMeta = item.getItemMeta();
+			String name = itemMeta.hasDisplayName() ? itemMeta.getDisplayName() : rewardParser.getItemName(item);
+			itemNames.add(StringUtils.replaceEach(langItemRewardReceived, new String[] { "AMOUNT", "ITEM" },
+					new String[] { Integer.toString(item.getAmount()), name }));
 		}
-		ItemMeta itemMeta = item.getItemMeta();
-		String name = itemMeta.hasDisplayName() ? itemMeta.getDisplayName() : rewardParser.getItemName(item);
-		return StringUtils.replaceEach(langItemRewardReceived, new String[] { "AMOUNT", "ITEM" },
-				new String[] { Integer.toString(item.getAmount()), name });
+		return itemNames;
 	}
 
 	/**

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/PlayerAdvancedAchievementListener.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/PlayerAdvancedAchievementListener.java
@@ -200,13 +200,13 @@ public class PlayerAdvancedAchievementListener implements Listener, Reloadable {
 	 * @return all the reward texts to be displayed to the user
 	 */
 	private List<String> giveRewardsAndPrepareTexts(Player player, String[] commands, List<String> commandMessages,
-													ItemStack[] item, int money, int experience, int health, int oxygen) {
+													ItemStack[] items, int money, int experience, int health, int oxygen) {
 		List<String> rewardTexts = new ArrayList<>();
 		if (commands != null && commands.length > 0) {
 			rewardTexts.addAll(rewardCommands(commands, commandMessages));
 		}
-		if (item != null) {
-			rewardTexts.addAll(rewardItem(player, item));
+		if (items != null) {
+			rewardTexts.addAll(rewardItems(player, items));
 		}
 		if (money != 0) {
 			rewardTexts.add(rewardMoney(player, money));
@@ -253,7 +253,7 @@ public class PlayerAdvancedAchievementListener implements Listener, Reloadable {
 	 * @param items
 	 * @return the reward text to display to the player
 	 */
-	private List<String> rewardItem(Player player, ItemStack[] items) {
+	private List<String> rewardItems(Player player, ItemStack[] items) {
 		List<String> itemNames = new ArrayList<>();
 		for (ItemStack item : items) {
 			if (player.getInventory().firstEmpty() != -1) {

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/PlayerAdvancedAchievementListener.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/PlayerAdvancedAchievementListener.java
@@ -200,7 +200,7 @@ public class PlayerAdvancedAchievementListener implements Listener, Reloadable {
 	 * @return all the reward texts to be displayed to the user
 	 */
 	private List<String> giveRewardsAndPrepareTexts(Player player, String[] commands, List<String> commandMessages,
-													ItemStack[] items, int money, int experience, int health, int oxygen) {
+			ItemStack[] items, int money, int experience, int health, int oxygen) {
 		List<String> rewardTexts = new ArrayList<>();
 		if (commands != null && commands.length > 0) {
 			rewardTexts.addAll(rewardCommands(commands, commandMessages));

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/ConnectionsListener.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/listener/statistics/ConnectionsListener.java
@@ -114,7 +114,7 @@ public class ConnectionsListener extends AbstractListener implements Cleanable {
 						.message(mainConfig.getString(achievementPath + ".Message"))
 						.commandRewards(rewardParser.getCommandRewards(rewardPath, player))
 						.commandMessage(rewardParser.getCustomCommandMessages(rewardPath))
-						.itemReward(rewardParser.getItemReward(rewardPath, player))
+						.itemRewards(rewardParser.getItemRewards(rewardPath, player))
 						.moneyReward(rewardParser.getRewardAmount(rewardPath, "Money"))
 						.experienceReward(rewardParser.getRewardAmount(rewardPath, "Experience"))
 						.maxHealthReward(rewardParser.getRewardAmount(rewardPath, "IncreaseMaxHealth"))

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/RewardParser.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/RewardParser.java
@@ -97,8 +97,8 @@ public class RewardParser implements Reloadable {
 		}
 
 		if (keyNames.contains(path + ".Item")) {
-			ItemStack[] itemReward = getItemReward(path, player);
-			for (ItemStack item: itemReward) {
+			ItemStack[] items = getItemRewards(path, player);
+			for (ItemStack item: items) {
 				ItemMeta itemMeta = item.getItemMeta();
 				String name = itemMeta.hasDisplayName() ? itemMeta.getDisplayName() : getItemName(item);
 				rewardTypes.add(StringUtils.replaceEach(langListRewardItem, new String[] { "AMOUNT", "ITEM" },
@@ -172,7 +172,7 @@ public class RewardParser implements Reloadable {
 	 * @param player
 	 * @return ItemStack object corresponding to the reward
 	 */
-	public ItemStack[] getItemReward(String path, Player player) {
+	public ItemStack[] getItemRewards(String path, Player player) {
 		String itemString = StringUtils.normalizeSpace(mainConfig.getString(path + ".Item", ""));
 		if (!itemString.contains(" ")) {
 			return null;

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/RewardParser.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/RewardParser.java
@@ -36,7 +36,7 @@ import net.milkbowl.vault.economy.Economy;
 @Singleton
 public class RewardParser implements Reloadable {
 
-	private static final Pattern MULTIPLE_REWARD_COMMANDS_SPLITTER = Pattern.compile(";\\s*");
+	private static final Pattern MULTIPLE_REWARDS_SPLITTER = Pattern.compile(";\\s*");
 
 	private final CommentedYamlConfiguration mainConfig;
 	private final CommentedYamlConfiguration langConfig;
@@ -97,11 +97,13 @@ public class RewardParser implements Reloadable {
 		}
 
 		if (keyNames.contains(path + ".Item")) {
-			ItemStack itemReward = getItemReward(path, player);
-			ItemMeta itemMeta = itemReward.getItemMeta();
-			String name = itemMeta.hasDisplayName() ? itemMeta.getDisplayName() : getItemName(itemReward);
-			rewardTypes.add(StringUtils.replaceEach(langListRewardItem, new String[] { "AMOUNT", "ITEM" },
-					new String[] { Integer.toString(itemReward.getAmount()), name }));
+			ItemStack[] itemReward = getItemReward(path, player);
+			for (ItemStack item: itemReward) {
+				ItemMeta itemMeta = item.getItemMeta();
+				String name = itemMeta.hasDisplayName() ? itemMeta.getDisplayName() : getItemName(item);
+				rewardTypes.add(StringUtils.replaceEach(langListRewardItem, new String[] { "AMOUNT", "ITEM" },
+						new String[] { Integer.toString(item.getAmount()), name }));
+			}
 		}
 
 		if (keyNames.contains(path + ".Experience")) {
@@ -170,25 +172,31 @@ public class RewardParser implements Reloadable {
 	 * @param player
 	 * @return ItemStack object corresponding to the reward
 	 */
-	public ItemStack getItemReward(String path, Player player) {
-		String itemReward = StringUtils.normalizeSpace(mainConfig.getString(path + ".Item", ""));
-		if (!itemReward.contains(" ")) {
+	public ItemStack[] getItemReward(String path, Player player) {
+		String itemString = StringUtils.normalizeSpace(mainConfig.getString(path + ".Item", ""));
+		if (!itemString.contains(" ")) {
 			return null;
 		}
 
-		String[] parts = StringUtils.split(itemReward);
-		Optional<Material> rewardMaterial = materialHelper.matchMaterial(parts[0], "config.yml (" + (path + ".Item") + ")");
-		if (rewardMaterial.isPresent()) {
-			ItemStack item = new ItemStack(rewardMaterial.get(), NumberUtils.toInt(parts[1], 1));
-			ItemMeta meta = item.getItemMeta();
-			String name = replacePlayerPlaceholders(StringUtils.join(parts, " ", 2, parts.length), player);
-			if (!name.isEmpty()) {
-				meta.setDisplayName(name);
+		String[] itemStrings = MULTIPLE_REWARDS_SPLITTER.split(itemString);
+		ItemStack[] itemData = new ItemStack[itemStrings.length];
+		for (int i = 0; i < itemStrings.length; i++) {
+			String[] parts = StringUtils.split(itemStrings[i]);
+			Optional<Material> rewardMaterial = materialHelper.matchMaterial(parts[0], "config.yml (" + (path + ".Item") + ")");
+			if (rewardMaterial.isPresent()) {
+				ItemStack item = new ItemStack(rewardMaterial.get(), NumberUtils.toInt(parts[1], 1));
+				ItemMeta meta = item.getItemMeta();
+				String name = replacePlayerPlaceholders(StringUtils.join(parts, " ", 2, parts.length), player);
+				if (!name.isEmpty()) {
+					meta.setDisplayName(name);
+				}
+				item.setItemMeta(meta);
+				itemData[i] = item;
+			} else {
+				return null;
 			}
-			item.setItemMeta(meta);
-			return item;
 		}
-		return null;
+		return itemData;
 	}
 
 	/**
@@ -209,7 +217,7 @@ public class RewardParser implements Reloadable {
 			return new String[0];
 		}
 		// Multiple reward commands can be set, separated by a semicolon and space. Extra parsing needed.
-		return MULTIPLE_REWARD_COMMANDS_SPLITTER.split(replacePlayerPlaceholders(commandReward, player));
+		return MULTIPLE_REWARDS_SPLITTER.split(replacePlayerPlaceholders(commandReward, player));
 	}
 
 	/**

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/RewardParser.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/RewardParser.java
@@ -98,7 +98,7 @@ public class RewardParser implements Reloadable {
 
 		if (keyNames.contains(path + ".Item")) {
 			ItemStack[] items = getItemRewards(path, player);
-			for (ItemStack item: items) {
+			for (ItemStack item : items) {
 				ItemMeta itemMeta = item.getItemMeta();
 				String name = itemMeta.hasDisplayName() ? itemMeta.getDisplayName() : getItemName(item);
 				rewardTypes.add(StringUtils.replaceEach(langListRewardItem, new String[] { "AMOUNT", "ITEM" },
@@ -182,7 +182,8 @@ public class RewardParser implements Reloadable {
 		ItemStack[] itemData = new ItemStack[itemStrings.length];
 		for (int i = 0; i < itemStrings.length; i++) {
 			String[] parts = StringUtils.split(itemStrings[i]);
-			Optional<Material> rewardMaterial = materialHelper.matchMaterial(parts[0], "config.yml (" + (path + ".Item") + ")");
+			Optional<Material> rewardMaterial = materialHelper.matchMaterial(parts[0],
+					"config.yml (" + (path + ".Item") + ")");
 			if (rewardMaterial.isPresent()) {
 				ItemStack item = new ItemStack(rewardMaterial.get(), NumberUtils.toInt(parts[1], 1));
 				ItemMeta meta = item.getItemMeta();

--- a/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/StatisticIncreaseHandler.java
+++ b/advanced-achievements-plugin/src/main/java/com/hm/achievement/utils/StatisticIncreaseHandler.java
@@ -86,7 +86,7 @@ public class StatisticIncreaseHandler implements Reloadable {
 							.message(mainConfig.getString(achievementPath + ".Message"))
 							.commandRewards(rewardParser.getCommandRewards(rewardPath, player))
 							.commandMessage(rewardParser.getCustomCommandMessages(rewardPath))
-							.itemReward(rewardParser.getItemReward(rewardPath, player))
+							.itemRewards(rewardParser.getItemRewards(rewardPath, player))
 							.moneyReward(rewardParser.getRewardAmount(rewardPath, "Money"))
 							.experienceReward(rewardParser.getRewardAmount(rewardPath, "Experience"))
 							.maxHealthReward(rewardParser.getRewardAmount(rewardPath, "IncreaseMaxHealth"))

--- a/advanced-achievements-plugin/src/main/resources/config-CN.yml
+++ b/advanced-achievements-plugin/src/main/resources/config-CN.yml
@@ -775,7 +775,7 @@ AdvancementsCompleted:
     Name: advancements_20
     DisplayName: 
     Reward:
-      Item: diamond 8;cake 1
+      Item: diamond 8; cake 1
   
 #===========================OOOOOOO===========================#
 # VII-----------------------------------------------------VII #

--- a/advanced-achievements-plugin/src/main/resources/config-CN.yml
+++ b/advanced-achievements-plugin/src/main/resources/config-CN.yml
@@ -774,6 +774,8 @@ AdvancementsCompleted:
     Message: 成功完成20个成就！
     Name: advancements_20
     DisplayName: 
+    Reward:
+      Item: diamond 8;cake 1
   
 #===========================OOOOOOO===========================#
 # VII-----------------------------------------------------VII #

--- a/advanced-achievements-plugin/src/main/resources/config.yml
+++ b/advanced-achievements-plugin/src/main/resources/config.yml
@@ -776,7 +776,7 @@ AdvancementsCompleted:
     DisplayName: Game Block Advance
     # Use semicolons for multiple item rewards as well. The below example will reward 8 diamond and 1 cake
     Reward:
-      Item: diamond 8;cake 1
+      Item: diamond 8; cake 1
   
 #===========================OOOOOOO===========================#
 # VII-----------------------------------------------------VII #

--- a/advanced-achievements-plugin/src/main/resources/config.yml
+++ b/advanced-achievements-plugin/src/main/resources/config.yml
@@ -774,6 +774,9 @@ AdvancementsCompleted:
     Message: 20 advancements completed!
     Name: advancements_20
     DisplayName: Game Block Advance
+    # Use semicolons for multiple item rewards as well. The below example will reward 8 diamond and 1 cake
+    Reward:
+      Item: diamond 8;cake 1
   
 #===========================OOOOOOO===========================#
 # VII-----------------------------------------------------VII #

--- a/advanced-achievements-plugin/src/test/java/com/hm/achievement/listener/PlayerAdvancedAchievementListenerTest.java
+++ b/advanced-achievements-plugin/src/test/java/com/hm/achievement/listener/PlayerAdvancedAchievementListenerTest.java
@@ -90,7 +90,7 @@ public class PlayerAdvancedAchievementListenerTest {
 
 		PlayerAdvancedAchievementEvent event = new PlayerAdvancedAchievementEventBuilder().player(player)
 				.name("connect_1").displayName("Good Choice").message("Connected for the first time!")
-				.commandRewards(new String[0]).commandMessage(Collections.emptyList()).itemReward(null)
+				.commandRewards(new String[0]).commandMessage(Collections.emptyList()).itemRewards(null)
 				.moneyReward(0).experienceReward(0).maxHealthReward(0).maxOxygenReward(0).build();
 
 		underTest.onPlayerAdvancedAchievementReception(event);
@@ -107,7 +107,7 @@ public class PlayerAdvancedAchievementListenerTest {
 
 		PlayerAdvancedAchievementEvent event = new PlayerAdvancedAchievementEventBuilder().player(player)
 				.name("connect_1").displayName("Good Choice").message("Connected for the first time!")
-				.commandRewards(new String[0]).commandMessage(Collections.emptyList()).itemReward(null)
+				.commandRewards(new String[0]).commandMessage(Collections.emptyList()).itemRewards(null)
 				.moneyReward(0).experienceReward(0).maxHealthReward(0).maxOxygenReward(0).build();
 
 		underTest.onPlayerAdvancedAchievementReception(event);


### PR DESCRIPTION
I've added support for including multiple items in an achievement reward as I asked about on #774 

You can do this like so in the following format:

```
Reward:
  Item: item num; item num
```

I also included an example in the config, but I need the example in the CN config to have a translated comment.

Please let me know if I've overlooked anything in the code, I don't know Java or coding Minecraft plugins very well. Thank you.